### PR TITLE
feat: Make Grund configurable for public use

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -3,30 +3,72 @@ package cli
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/vivekkundariya/grund/internal/application/wiring"
+	"github.com/vivekkundariya/grund/internal/config"
 )
 
-var container *wiring.Container
+var (
+	container      *wiring.Container
+	configResolver *config.ConfigResolver
+	
+	// CLI flags
+	configFile string
+	verbose    bool
+)
 
 var rootCmd = &cobra.Command{
 	Use:   "grund",
 	Short: "Grund - Local development orchestration tool",
 	Long: `Grund is a CLI tool that enables developers to selectively spin up 
-services and their dependencies with a single command.`,
-	Version: "0.1.0",
+services and their dependencies with a single command.
+
+Configuration Priority:
+  1. --config flag (highest priority)
+  2. GRUND_CONFIG environment variable
+  3. Local services.yaml in current/parent directory
+  4. Global config default (~/.grund/config.yaml)
+
+Examples:
+  grund up service-a service-b    Start services with dependencies
+  grund down                      Stop all services
+  grund status                    Show service status
+  grund --config=/path/to/services.yaml up myservice`,
+	Version: "1.0.0",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		// Initialize dependency injection container
-		root, err := getOrchestrationRoot()
+		// Skip initialization for help and version commands
+		if cmd.Name() == "help" || cmd.Name() == "version" {
+			return nil
+		}
+		
+		// Also skip for completion commands
+		if cmd.Name() == "completion" {
+			return nil
+		}
+		
+		// Initialize config resolver
+		var err error
+		configResolver, err = config.NewConfigResolver(configFile)
+		if err != nil {
+			return fmt.Errorf("failed to initialize config: %w", err)
+		}
+		
+		// Resolve services file and orchestration root
+		servicesPath, orchestrationRoot, err := configResolver.ResolveServicesFile()
 		if err != nil {
 			return err
 		}
-
-		container, err = wiring.NewContainer(root)
+		
+		if verbose {
+			fmt.Fprintf(os.Stderr, "Using config: %s\n", servicesPath)
+			fmt.Fprintf(os.Stderr, "Orchestration root: %s\n", orchestrationRoot)
+		}
+		
+		// Initialize dependency injection container
+		container, err = wiring.NewContainerWithConfig(orchestrationRoot, servicesPath, configResolver)
 		if err != nil {
-			return fmt.Errorf("failed to initialize container: %w", err)
+			return fmt.Errorf("failed to initialize: %w", err)
 		}
 
 		return nil
@@ -39,6 +81,13 @@ func Execute() error {
 }
 
 func init() {
+	// Global flags
+	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", 
+		"Path to services registry file (default: auto-detect services.yaml)")
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, 
+		"Enable verbose output")
+	
+	// Add subcommands
 	rootCmd.AddCommand(upCmd)
 	rootCmd.AddCommand(downCmd)
 	rootCmd.AddCommand(statusCmd)
@@ -48,28 +97,31 @@ func init() {
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(cloneCmd)
+	rootCmd.AddCommand(newConfigInitCmd())
 }
 
-// getOrchestrationRoot returns the path to the orchestration repo root
-func getOrchestrationRoot() (string, error) {
-	// Try to find services.yaml in current directory or parent
-	wd, err := os.Getwd()
-	if err != nil {
-		return "", fmt.Errorf("failed to get working directory: %w", err)
-	}
+// newConfigInitCmd creates the config init subcommand
+func newConfigInitCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "config-init",
+		Short: "Initialize global Grund configuration",
+		Long: `Initialize the global Grund configuration at ~/.grund/config.yaml.
 
-	// Look for services.yaml in current and parent directories
-	path := wd
-	for i := 0; i < 5; i++ {
-		servicesPath := filepath.Join(path, "services.yaml")
-		if _, err := os.Stat(servicesPath); err == nil {
-			return path, nil
-		}
-		path = filepath.Dir(path)
-		if path == "/" || path == "." {
-			break
-		}
+This creates a default configuration file that you can customize.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := config.InitGlobalConfig(); err != nil {
+				return fmt.Errorf("failed to initialize config: %w", err)
+			}
+			
+			configPath, _ := config.GetGlobalConfigPath()
+			fmt.Printf("Global config initialized at: %s\n", configPath)
+			fmt.Println("\nYou can customize this file to set default paths and options.")
+			return nil
+		},
 	}
+}
 
-	return "", fmt.Errorf("services.yaml not found. Are you in the orchestration repo?")
+// GetConfigResolver returns the current config resolver (for use by subcommands)
+func GetConfigResolver() *config.ConfigResolver {
+	return configResolver
 }

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -1,0 +1,186 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// DefaultConfigFileName is the default name for the services registry file
+	DefaultConfigFileName = "services.yaml"
+	
+	// GlobalConfigDir is the directory for global Grund configuration
+	GlobalConfigDir = ".grund"
+	
+	// GlobalConfigFile is the global configuration file name
+	GlobalConfigFile = "config.yaml"
+	
+	// EnvConfigFile is the environment variable for custom config file path
+	EnvConfigFile = "GRUND_CONFIG"
+	
+	// EnvGrundHome is the environment variable for Grund home directory
+	EnvGrundHome = "GRUND_HOME"
+)
+
+// GlobalConfig represents the global Grund configuration
+// stored at ~/.grund/config.yaml
+type GlobalConfig struct {
+	// DefaultServicesFile is the default path to services.yaml
+	// Can be absolute or relative to current directory
+	DefaultServicesFile string `yaml:"default_services_file,omitempty"`
+	
+	// DefaultOrchestrationRepo is the default path to the orchestration repo
+	DefaultOrchestrationRepo string `yaml:"default_orchestration_repo,omitempty"`
+	
+	// ServicesBasePath is the base path where services are cloned
+	ServicesBasePath string `yaml:"services_base_path,omitempty"`
+	
+	// Docker configuration
+	Docker DockerConfig `yaml:"docker,omitempty"`
+	
+	// LocalStack configuration
+	LocalStack LocalStackConfig `yaml:"localstack,omitempty"`
+}
+
+// DockerConfig holds Docker-related configuration
+type DockerConfig struct {
+	// ComposeCommand is the docker compose command (default: "docker compose")
+	ComposeCommand string `yaml:"compose_command,omitempty"`
+}
+
+// LocalStackConfig holds LocalStack-related configuration
+type LocalStackConfig struct {
+	// Endpoint is the LocalStack endpoint (default: "http://localhost:4566")
+	Endpoint string `yaml:"endpoint,omitempty"`
+	
+	// Region is the AWS region for LocalStack (default: "us-east-1")
+	Region string `yaml:"region,omitempty"`
+}
+
+// GetGrundHome returns the Grund home directory
+// Priority: GRUND_HOME env var > ~/.grund
+func GetGrundHome() (string, error) {
+	if home := os.Getenv(EnvGrundHome); home != "" {
+		return home, nil
+	}
+	
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get user home directory: %w", err)
+	}
+	
+	return filepath.Join(userHome, GlobalConfigDir), nil
+}
+
+// GetGlobalConfigPath returns the path to the global config file
+func GetGlobalConfigPath() (string, error) {
+	grundHome, err := GetGrundHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(grundHome, GlobalConfigFile), nil
+}
+
+// LoadGlobalConfig loads the global configuration
+// Returns default config if file doesn't exist
+func LoadGlobalConfig() (*GlobalConfig, error) {
+	configPath, err := GetGlobalConfigPath()
+	if err != nil {
+		return DefaultGlobalConfig(), nil
+	}
+	
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return DefaultGlobalConfig(), nil
+		}
+		return nil, fmt.Errorf("failed to read global config: %w", err)
+	}
+	
+	var config GlobalConfig
+	if err := yaml.Unmarshal(data, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse global config: %w", err)
+	}
+	
+	// Apply defaults for unset values
+	config.applyDefaults()
+	
+	return &config, nil
+}
+
+// SaveGlobalConfig saves the global configuration
+func SaveGlobalConfig(config *GlobalConfig) error {
+	grundHome, err := GetGrundHome()
+	if err != nil {
+		return err
+	}
+	
+	// Create directory if it doesn't exist
+	if err := os.MkdirAll(grundHome, 0755); err != nil {
+		return fmt.Errorf("failed to create config directory: %w", err)
+	}
+	
+	configPath := filepath.Join(grundHome, GlobalConfigFile)
+	
+	data, err := yaml.Marshal(config)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+	
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+	
+	return nil
+}
+
+// DefaultGlobalConfig returns the default global configuration
+func DefaultGlobalConfig() *GlobalConfig {
+	return &GlobalConfig{
+		DefaultServicesFile: DefaultConfigFileName,
+		Docker: DockerConfig{
+			ComposeCommand: "docker compose",
+		},
+		LocalStack: LocalStackConfig{
+			Endpoint: "http://localhost:4566",
+			Region:   "us-east-1",
+		},
+	}
+}
+
+// applyDefaults applies default values to unset fields
+func (c *GlobalConfig) applyDefaults() {
+	defaults := DefaultGlobalConfig()
+	
+	if c.DefaultServicesFile == "" {
+		c.DefaultServicesFile = defaults.DefaultServicesFile
+	}
+	if c.Docker.ComposeCommand == "" {
+		c.Docker.ComposeCommand = defaults.Docker.ComposeCommand
+	}
+	if c.LocalStack.Endpoint == "" {
+		c.LocalStack.Endpoint = defaults.LocalStack.Endpoint
+	}
+	if c.LocalStack.Region == "" {
+		c.LocalStack.Region = defaults.LocalStack.Region
+	}
+}
+
+// InitGlobalConfig initializes the global config directory and file
+func InitGlobalConfig() error {
+	configPath, err := GetGlobalConfigPath()
+	if err != nil {
+		return err
+	}
+	
+	// Check if config already exists
+	if _, err := os.Stat(configPath); err == nil {
+		return nil // Already exists
+	}
+	
+	// Create default config
+	return SaveGlobalConfig(DefaultGlobalConfig())
+}

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetGrundHome_Default(t *testing.T) {
+	// Clear env var to test default
+	os.Unsetenv(EnvGrundHome)
+
+	home, err := GetGrundHome()
+	if err != nil {
+		t.Fatalf("GetGrundHome() error: %v", err)
+	}
+
+	userHome, _ := os.UserHomeDir()
+	expected := filepath.Join(userHome, GlobalConfigDir)
+
+	if home != expected {
+		t.Errorf("GetGrundHome() = %q, want %q", home, expected)
+	}
+}
+
+func TestGetGrundHome_EnvVar(t *testing.T) {
+	customHome := "/custom/grund/home"
+	os.Setenv(EnvGrundHome, customHome)
+	defer os.Unsetenv(EnvGrundHome)
+
+	home, err := GetGrundHome()
+	if err != nil {
+		t.Fatalf("GetGrundHome() error: %v", err)
+	}
+
+	if home != customHome {
+		t.Errorf("GetGrundHome() = %q, want %q", home, customHome)
+	}
+}
+
+func TestLoadGlobalConfig_NotExists(t *testing.T) {
+	// Use temp directory as GRUND_HOME
+	tmpDir := t.TempDir()
+	os.Setenv(EnvGrundHome, tmpDir)
+	defer os.Unsetenv(EnvGrundHome)
+
+	config, err := LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("LoadGlobalConfig() error: %v", err)
+	}
+
+	// Should return defaults when file doesn't exist
+	if config.DefaultServicesFile != DefaultConfigFileName {
+		t.Errorf("Expected default services file, got %q", config.DefaultServicesFile)
+	}
+}
+
+func TestSaveAndLoadGlobalConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv(EnvGrundHome, tmpDir)
+	defer os.Unsetenv(EnvGrundHome)
+
+	// Create custom config
+	config := &GlobalConfig{
+		DefaultServicesFile:      "my-services.yaml",
+		DefaultOrchestrationRepo: "~/my-orchestration",
+		ServicesBasePath:         "~/my-projects",
+		Docker: DockerConfig{
+			ComposeCommand: "docker-compose",
+		},
+		LocalStack: LocalStackConfig{
+			Endpoint: "http://localhost:4567",
+			Region:   "eu-west-1",
+		},
+	}
+
+	// Save it
+	if err := SaveGlobalConfig(config); err != nil {
+		t.Fatalf("SaveGlobalConfig() error: %v", err)
+	}
+
+	// Verify file exists
+	configPath := filepath.Join(tmpDir, GlobalConfigFile)
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Fatal("Config file was not created")
+	}
+
+	// Load it back
+	loaded, err := LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("LoadGlobalConfig() error: %v", err)
+	}
+
+	// Verify values
+	if loaded.DefaultServicesFile != "my-services.yaml" {
+		t.Errorf("DefaultServicesFile = %q, want 'my-services.yaml'", loaded.DefaultServicesFile)
+	}
+	if loaded.DefaultOrchestrationRepo != "~/my-orchestration" {
+		t.Errorf("DefaultOrchestrationRepo = %q, want '~/my-orchestration'", loaded.DefaultOrchestrationRepo)
+	}
+	if loaded.Docker.ComposeCommand != "docker-compose" {
+		t.Errorf("Docker.ComposeCommand = %q, want 'docker-compose'", loaded.Docker.ComposeCommand)
+	}
+	if loaded.LocalStack.Endpoint != "http://localhost:4567" {
+		t.Errorf("LocalStack.Endpoint = %q, want 'http://localhost:4567'", loaded.LocalStack.Endpoint)
+	}
+}
+
+func TestInitGlobalConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv(EnvGrundHome, tmpDir)
+	defer os.Unsetenv(EnvGrundHome)
+
+	if err := InitGlobalConfig(); err != nil {
+		t.Fatalf("InitGlobalConfig() error: %v", err)
+	}
+
+	// Verify file was created
+	configPath := filepath.Join(tmpDir, GlobalConfigFile)
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Fatal("Config file was not created")
+	}
+
+	// Calling again should be safe (idempotent)
+	if err := InitGlobalConfig(); err != nil {
+		t.Fatalf("InitGlobalConfig() second call error: %v", err)
+	}
+}
+
+func TestGlobalConfig_ApplyDefaults(t *testing.T) {
+	config := &GlobalConfig{
+		// Leave everything empty
+	}
+
+	config.applyDefaults()
+
+	if config.DefaultServicesFile != DefaultConfigFileName {
+		t.Errorf("DefaultServicesFile should have default, got %q", config.DefaultServicesFile)
+	}
+	if config.Docker.ComposeCommand != "docker compose" {
+		t.Errorf("Docker.ComposeCommand should have default, got %q", config.Docker.ComposeCommand)
+	}
+	if config.LocalStack.Endpoint != "http://localhost:4566" {
+		t.Errorf("LocalStack.Endpoint should have default, got %q", config.LocalStack.Endpoint)
+	}
+	if config.LocalStack.Region != "us-east-1" {
+		t.Errorf("LocalStack.Region should have default, got %q", config.LocalStack.Region)
+	}
+}
+
+func TestGlobalConfig_PartialConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	os.Setenv(EnvGrundHome, tmpDir)
+	defer os.Unsetenv(EnvGrundHome)
+
+	// Write partial config (only some fields)
+	configPath := filepath.Join(tmpDir, GlobalConfigFile)
+	partialConfig := `
+default_services_file: custom.yaml
+docker:
+  compose_command: podman-compose
+`
+	os.WriteFile(configPath, []byte(partialConfig), 0644)
+
+	config, err := LoadGlobalConfig()
+	if err != nil {
+		t.Fatalf("LoadGlobalConfig() error: %v", err)
+	}
+
+	// Custom values should be loaded
+	if config.DefaultServicesFile != "custom.yaml" {
+		t.Errorf("Expected custom services file, got %q", config.DefaultServicesFile)
+	}
+	if config.Docker.ComposeCommand != "podman-compose" {
+		t.Errorf("Expected custom compose command, got %q", config.Docker.ComposeCommand)
+	}
+
+	// Unset values should have defaults
+	if config.LocalStack.Endpoint != "http://localhost:4566" {
+		t.Errorf("Expected default localstack endpoint, got %q", config.LocalStack.Endpoint)
+	}
+}

--- a/internal/config/resolver.go
+++ b/internal/config/resolver.go
@@ -1,0 +1,167 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConfigResolver resolves configuration from multiple sources
+// Priority order (highest to lowest):
+// 1. CLI flag (--config)
+// 2. Environment variable (GRUND_CONFIG)
+// 3. Local file (./services.yaml or ./grund-services.yaml)
+// 4. Global config default path
+type ConfigResolver struct {
+	// CLIConfigPath is set via --config flag
+	CLIConfigPath string
+	
+	// GlobalConfig is the loaded global configuration
+	GlobalConfig *GlobalConfig
+}
+
+// NewConfigResolver creates a new config resolver
+func NewConfigResolver(cliConfigPath string) (*ConfigResolver, error) {
+	globalConfig, err := LoadGlobalConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load global config: %w", err)
+	}
+	
+	return &ConfigResolver{
+		CLIConfigPath: cliConfigPath,
+		GlobalConfig:  globalConfig,
+	}, nil
+}
+
+// ResolveServicesFile resolves the path to the services registry file
+// Returns the resolved path and the orchestration root directory
+func (r *ConfigResolver) ResolveServicesFile() (servicesPath string, orchestrationRoot string, err error) {
+	// 1. CLI flag has highest priority
+	if r.CLIConfigPath != "" {
+		absPath, err := filepath.Abs(r.CLIConfigPath)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to resolve CLI config path: %w", err)
+		}
+		
+		if _, err := os.Stat(absPath); err != nil {
+			return "", "", fmt.Errorf("config file not found: %s", absPath)
+		}
+		
+		return absPath, filepath.Dir(absPath), nil
+	}
+	
+	// 2. Environment variable
+	if envPath := os.Getenv(EnvConfigFile); envPath != "" {
+		absPath, err := filepath.Abs(envPath)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to resolve GRUND_CONFIG path: %w", err)
+		}
+		
+		if _, err := os.Stat(absPath); err != nil {
+			return "", "", fmt.Errorf("config file from GRUND_CONFIG not found: %s", absPath)
+		}
+		
+		return absPath, filepath.Dir(absPath), nil
+	}
+	
+	// 3. Search for local file in current and parent directories
+	localPath, localRoot, found := r.findLocalServicesFile()
+	if found {
+		return localPath, localRoot, nil
+	}
+	
+	// 4. Check global config default orchestration repo
+	if r.GlobalConfig.DefaultOrchestrationRepo != "" {
+		expandedPath := expandPath(r.GlobalConfig.DefaultOrchestrationRepo)
+		servicesPath := filepath.Join(expandedPath, r.GlobalConfig.DefaultServicesFile)
+		
+		if _, err := os.Stat(servicesPath); err == nil {
+			return servicesPath, expandedPath, nil
+		}
+	}
+	
+	return "", "", fmt.Errorf("services file not found. Use --config flag, set GRUND_CONFIG env var, or run from orchestration repo")
+}
+
+// findLocalServicesFile searches for services file in current and parent directories
+func (r *ConfigResolver) findLocalServicesFile() (string, string, bool) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", "", false
+	}
+	
+	// Files to search for (in priority order)
+	searchFiles := []string{
+		r.GlobalConfig.DefaultServicesFile, // services.yaml (configurable)
+		"grund-services.yaml",              // Alternative name
+		"grund.services.yaml",              // Alternative name
+	}
+	
+	// Search up to 5 parent directories
+	path := wd
+	for i := 0; i < 5; i++ {
+		for _, fileName := range searchFiles {
+			servicesPath := filepath.Join(path, fileName)
+			if _, err := os.Stat(servicesPath); err == nil {
+				return servicesPath, path, true
+			}
+		}
+		
+		parent := filepath.Dir(path)
+		if parent == path || parent == "/" || parent == "." {
+			break
+		}
+		path = parent
+	}
+	
+	return "", "", false
+}
+
+// expandPath expands ~ to home directory
+func expandPath(path string) string {
+	if len(path) == 0 {
+		return path
+	}
+	
+	if path[0] == '~' {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return path
+		}
+		if len(path) > 1 {
+			return filepath.Join(home, path[2:])
+		}
+		return home
+	}
+	
+	return path
+}
+
+// GetServicesBasePath returns the base path for cloning services
+func (r *ConfigResolver) GetServicesBasePath() string {
+	if r.GlobalConfig.ServicesBasePath != "" {
+		return expandPath(r.GlobalConfig.ServicesBasePath)
+	}
+	
+	// Default to ~/projects
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "./services"
+	}
+	return filepath.Join(home, "projects")
+}
+
+// GetDockerComposeCommand returns the docker compose command
+func (r *ConfigResolver) GetDockerComposeCommand() string {
+	return r.GlobalConfig.Docker.ComposeCommand
+}
+
+// GetLocalStackEndpoint returns the LocalStack endpoint
+func (r *ConfigResolver) GetLocalStackEndpoint() string {
+	return r.GlobalConfig.LocalStack.Endpoint
+}
+
+// GetLocalStackRegion returns the LocalStack AWS region
+func (r *ConfigResolver) GetLocalStackRegion() string {
+	return r.GlobalConfig.LocalStack.Region
+}

--- a/internal/config/resolver_test.go
+++ b/internal/config/resolver_test.go
@@ -1,0 +1,276 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfigResolver_ResolveServicesFile_CLIFlag(t *testing.T) {
+	// Create temp services file
+	tmpDir := t.TempDir()
+	servicesFile := filepath.Join(tmpDir, "custom-services.yaml")
+	if err := os.WriteFile(servicesFile, []byte("version: 1\nservices: {}"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	resolver, err := NewConfigResolver(servicesFile)
+	if err != nil {
+		t.Fatalf("NewConfigResolver() error: %v", err)
+	}
+
+	path, root, err := resolver.ResolveServicesFile()
+	if err != nil {
+		t.Fatalf("ResolveServicesFile() error: %v", err)
+	}
+
+	if path != servicesFile {
+		t.Errorf("Expected path %s, got %s", servicesFile, path)
+	}
+
+	if root != tmpDir {
+		t.Errorf("Expected root %s, got %s", tmpDir, root)
+	}
+}
+
+func TestConfigResolver_ResolveServicesFile_EnvVar(t *testing.T) {
+	// Create temp services file
+	tmpDir := t.TempDir()
+	servicesFile := filepath.Join(tmpDir, "env-services.yaml")
+	if err := os.WriteFile(servicesFile, []byte("version: 1\nservices: {}"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Set environment variable
+	os.Setenv(EnvConfigFile, servicesFile)
+	defer os.Unsetenv(EnvConfigFile)
+
+	resolver, err := NewConfigResolver("") // No CLI flag
+	if err != nil {
+		t.Fatalf("NewConfigResolver() error: %v", err)
+	}
+
+	path, root, err := resolver.ResolveServicesFile()
+	if err != nil {
+		t.Fatalf("ResolveServicesFile() error: %v", err)
+	}
+
+	if path != servicesFile {
+		t.Errorf("Expected path %s, got %s", servicesFile, path)
+	}
+
+	if root != tmpDir {
+		t.Errorf("Expected root %s, got %s", tmpDir, root)
+	}
+}
+
+func TestConfigResolver_ResolveServicesFile_CLIOverridesEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create two different files
+	envFile := filepath.Join(tmpDir, "env-services.yaml")
+	cliFile := filepath.Join(tmpDir, "cli-services.yaml")
+
+	os.WriteFile(envFile, []byte("version: 1\nservices: {}"), 0644)
+	os.WriteFile(cliFile, []byte("version: 1\nservices: {}"), 0644)
+
+	// Set environment variable
+	os.Setenv(EnvConfigFile, envFile)
+	defer os.Unsetenv(EnvConfigFile)
+
+	// CLI flag should take priority
+	resolver, _ := NewConfigResolver(cliFile)
+	path, _, err := resolver.ResolveServicesFile()
+
+	if err != nil {
+		t.Fatalf("ResolveServicesFile() error: %v", err)
+	}
+
+	if path != cliFile {
+		t.Errorf("CLI flag should override env var. Expected %s, got %s", cliFile, path)
+	}
+}
+
+func TestConfigResolver_ResolveServicesFile_LocalFile(t *testing.T) {
+	// Create temp directory with services.yaml
+	tmpDir := t.TempDir()
+	servicesFile := filepath.Join(tmpDir, "services.yaml")
+	if err := os.WriteFile(servicesFile, []byte("version: 1\nservices: {}"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Change to temp directory
+	originalWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(originalWd)
+
+	resolver, err := NewConfigResolver("") // No CLI flag, no env var
+	if err != nil {
+		t.Fatalf("NewConfigResolver() error: %v", err)
+	}
+
+	path, root, err := resolver.ResolveServicesFile()
+	if err != nil {
+		t.Fatalf("ResolveServicesFile() error: %v", err)
+	}
+
+	// Resolve symlinks for comparison (macOS /var -> /private/var)
+	expectedPath, _ := filepath.EvalSymlinks(servicesFile)
+	expectedRoot, _ := filepath.EvalSymlinks(tmpDir)
+	actualPath, _ := filepath.EvalSymlinks(path)
+	actualRoot, _ := filepath.EvalSymlinks(root)
+
+	if actualPath != expectedPath {
+		t.Errorf("Expected path %s, got %s", expectedPath, actualPath)
+	}
+
+	if actualRoot != expectedRoot {
+		t.Errorf("Expected root %s, got %s", expectedRoot, actualRoot)
+	}
+}
+
+func TestConfigResolver_ResolveServicesFile_AlternativeNames(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create grund-services.yaml (alternative name)
+	servicesFile := filepath.Join(tmpDir, "grund-services.yaml")
+	if err := os.WriteFile(servicesFile, []byte("version: 1\nservices: {}"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	originalWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(originalWd)
+
+	resolver, _ := NewConfigResolver("")
+	path, _, err := resolver.ResolveServicesFile()
+
+	if err != nil {
+		t.Fatalf("ResolveServicesFile() error: %v", err)
+	}
+
+	// Resolve symlinks for comparison
+	expectedPath, _ := filepath.EvalSymlinks(servicesFile)
+	actualPath, _ := filepath.EvalSymlinks(path)
+
+	if actualPath != expectedPath {
+		t.Errorf("Expected alternative name to work. Expected %s, got %s", expectedPath, actualPath)
+	}
+}
+
+func TestConfigResolver_ResolveServicesFile_ParentDirectory(t *testing.T) {
+	// Create parent/child directory structure
+	tmpDir := t.TempDir()
+	childDir := filepath.Join(tmpDir, "child")
+	os.MkdirAll(childDir, 0755)
+
+	// Put services.yaml in parent
+	servicesFile := filepath.Join(tmpDir, "services.yaml")
+	os.WriteFile(servicesFile, []byte("version: 1\nservices: {}"), 0644)
+
+	// Change to child directory
+	originalWd, _ := os.Getwd()
+	os.Chdir(childDir)
+	defer os.Chdir(originalWd)
+
+	resolver, _ := NewConfigResolver("")
+	path, root, err := resolver.ResolveServicesFile()
+
+	if err != nil {
+		t.Fatalf("ResolveServicesFile() error: %v", err)
+	}
+
+	// Resolve symlinks for comparison
+	expectedPath, _ := filepath.EvalSymlinks(servicesFile)
+	expectedRoot, _ := filepath.EvalSymlinks(tmpDir)
+	actualPath, _ := filepath.EvalSymlinks(path)
+	actualRoot, _ := filepath.EvalSymlinks(root)
+
+	if actualPath != expectedPath {
+		t.Errorf("Should find services.yaml in parent. Expected %s, got %s", expectedPath, actualPath)
+	}
+
+	if actualRoot != expectedRoot {
+		t.Errorf("Root should be parent dir. Expected %s, got %s", expectedRoot, actualRoot)
+	}
+}
+
+func TestConfigResolver_ResolveServicesFile_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	originalWd, _ := os.Getwd()
+	os.Chdir(tmpDir)
+	defer os.Chdir(originalWd)
+
+	resolver, _ := NewConfigResolver("")
+	_, _, err := resolver.ResolveServicesFile()
+
+	if err == nil {
+		t.Error("Expected error when services file not found")
+	}
+}
+
+func TestConfigResolver_CLIFlagFileNotFound(t *testing.T) {
+	resolver, _ := NewConfigResolver("/nonexistent/services.yaml")
+	_, _, err := resolver.ResolveServicesFile()
+
+	if err == nil {
+		t.Error("Expected error when CLI flag points to nonexistent file")
+	}
+}
+
+func TestExpandPath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"~/projects", filepath.Join(home, "projects")},
+		{"~", home},
+		{"/absolute/path", "/absolute/path"},
+		{"relative/path", "relative/path"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := expandPath(tt.input)
+			if result != tt.expected {
+				t.Errorf("expandPath(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDefaultGlobalConfig(t *testing.T) {
+	config := DefaultGlobalConfig()
+
+	if config.DefaultServicesFile != "services.yaml" {
+		t.Errorf("Expected default services file 'services.yaml', got %q", config.DefaultServicesFile)
+	}
+
+	if config.Docker.ComposeCommand != "docker compose" {
+		t.Errorf("Expected docker compose command, got %q", config.Docker.ComposeCommand)
+	}
+
+	if config.LocalStack.Endpoint != "http://localhost:4566" {
+		t.Errorf("Expected localstack endpoint, got %q", config.LocalStack.Endpoint)
+	}
+}
+
+func TestConfigResolver_GetSettings(t *testing.T) {
+	resolver, _ := NewConfigResolver("")
+
+	if endpoint := resolver.GetLocalStackEndpoint(); endpoint != "http://localhost:4566" {
+		t.Errorf("Expected default localstack endpoint, got %q", endpoint)
+	}
+
+	if region := resolver.GetLocalStackRegion(); region != "us-east-1" {
+		t.Errorf("Expected default region, got %q", region)
+	}
+
+	if cmd := resolver.GetDockerComposeCommand(); cmd != "docker compose" {
+		t.Errorf("Expected default docker compose command, got %q", cmd)
+	}
+}


### PR DESCRIPTION
## Summary
This PR makes Grund a proper public CLI tool that anyone can use by making configuration flexible.

## Changes

### New Features
- **Global config** (~/.grund/config.yaml) for persistent settings
- **--config/-c flag** to specify custom services file path
- **GRUND_CONFIG env var** support
- **config-init command** to initialize global configuration
- **Alternative file names** support (grund-services.yaml, grund.services.yaml)
- **Auto-detection** in current and parent directories

### Configuration Priority (highest to lowest)
1. CLI flag (`--config`)
2. Environment variable (`GRUND_CONFIG`)
3. Local file detection (services.yaml, grund-services.yaml)
4. Global config default path

### Global Config Options (~/.grund/config.yaml)
```yaml
# Default services registry filename
default_services_file: services.yaml

# Default orchestration repo path
default_orchestration_repo: ~/my-orchestration

# Where to clone services
services_base_path: ~/projects

# Docker configuration
docker:
  compose_command: docker compose

# LocalStack configuration
localstack:
  endpoint: http://localhost:4566
  region: us-east-1
```

### Usage Examples
```bash
# Initialize global config
grund config-init

# Use custom config file
grund --config=/path/to/services.yaml up service-a

# Use environment variable
GRUND_CONFIG=/path/to/services.yaml grund up service-a

# Verbose mode to see resolved config
grund -v up service-a
```

## Tests
- Added comprehensive tests for config resolution
- All existing tests pass
