### PR TITLE
docs: Fix review issues before release

### DIFF
--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -41,6 +41,8 @@ grund down
 |----------|-------------|
 | [System Design](../plans/2026-01-22-localdev-system-design.md) | Original architecture decisions and rationale |
 | [Testing Strategy](../plans/2026-01-22-testing-strategy.md) | Testing approach and patterns |
+| [Secrets Management](../plans/2026-01-28-secrets-management-design.md) | Secrets handling design |
+| [SNS Filter Policy](../plans/2026-01-28-sns-filter-policy-design.md) | SNS subscription filtering |
 
 ## Key Concepts
 

--- a/docs/wiki/architecture.md
+++ b/docs/wiki/architecture.md
@@ -15,8 +15,8 @@ This document describes the architecture of Grund, which follows **SOLID princip
 **Decision Logs:**
 | Document | Description |
 |----------|-------------|
-| [System Design](plans/2026-01-22-localdev-system-design.md) | Original system design decisions |
-| [Testing Strategy](plans/2026-01-22-testing-strategy.md) | Testing approach and patterns |
+| [System Design](../plans/2026-01-22-localdev-system-design.md) | Original system design decisions |
+| [Testing Strategy](../plans/2026-01-22-testing-strategy.md) | Testing approach and patterns |
 
 ## Architecture Overview
 

--- a/docs/wiki/cli-commands.md
+++ b/docs/wiki/cli-commands.md
@@ -55,7 +55,6 @@ grund up [services...] [flags]
 7. Waits for infrastructure health checks
 8. Provisions resources (creates databases, SQS queues, SNS topics, S3 buckets)
 9. Starts all services in parallel (services handle reconnection)
-9. Starts application services in dependency order
 
 **Examples:**
 ```bash


### PR DESCRIPTION
## Summary

Cherry-pick of commit `06ca536` that was missed in PR #21 squash merge.

## Fixes

- Fix broken relative links in `architecture.md` (`plans/` → `../plans/`)
- Remove duplicate step 9 in `cli-commands.md`
- Add missing decision logs to `wiki/README.md`