### PR TITLE
feat: Improve tunnel infrastructure with early startup

### DIFF
--- a/docs/wiki/cli-commands.md
+++ b/docs/wiki/cli-commands.md
@@ -50,11 +50,12 @@ grund up [services...] [flags]
 2. Builds dependency graph (circular dependencies are allowed)
 3. Loads all transitive dependencies
 4. Aggregates infrastructure requirements from all services
-5. Generates per-service compose files in `~/.grund/tmp/`
-6. Starts infrastructure containers (postgres, mongodb, redis, localstack)
-7. Waits for infrastructure health checks
-8. Provisions resources (creates databases, SQS queues, SNS topics, S3 buckets)
-9. Starts all services in parallel (services handle reconnection)
+5. **Starts tunnels** (if configured) - cloudflared/ngrok for exposing LocalStack, etc.
+6. Generates per-service compose files in `~/.grund/tmp/` (with tunnel URLs resolved)
+7. Starts infrastructure containers (postgres, mongodb, redis, localstack)
+8. Waits for infrastructure health checks
+9. Provisions resources (creates databases, SQS queues, SNS topics, S3 buckets)
+10. Starts all services in parallel (services handle reconnection)
 
 **Examples:**
 ```bash
@@ -75,6 +76,18 @@ grund up user-service --build
 
 # Verbose output for debugging
 grund up user-service -v
+
+# Service with tunnel (LocalStack exposed via cloudflared)
+# Tunnel URL available as ${tunnel.localstack.url} in env_refs
+grund up s3-upload-service
+```
+
+**Tunnel Output Example:**
+```
+→ Starting tunnels...
+  localstack: https://abc-xyz.trycloudflare.com -> localhost:4566
+✓ Tunnels started
+→ Generating docker-compose configuration...
 ```
 
 ---

--- a/internal/application/commands/up_command_test.go
+++ b/internal/application/commands/up_command_test.go
@@ -43,6 +43,10 @@ func (m *mockServiceRepository) Save(svc *service.Service) error {
 	return nil
 }
 
+func (m *mockServiceRepository) ExtractTunnelConfig(name service.ServiceName) (*infrastructure.TunnelRequirement, error) {
+	return nil, nil
+}
+
 type mockRegistryRepository struct{}
 
 func (m *mockRegistryRepository) GetServicePath(name service.ServiceName) (string, error) {
@@ -131,6 +135,10 @@ func (m *mockComposeGenerator) Generate(services []*service.Service, infra infra
 		InfrastructurePath: "/tmp/infrastructure/docker-compose.yaml",
 		ServicePaths:       map[string]string{},
 	}, nil
+}
+
+func (m *mockComposeGenerator) GenerateWithTunnels(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext) (*ports.ComposeFileSet, error) {
+	return m.Generate(services, infra)
 }
 
 type mockHealthChecker struct{}

--- a/internal/application/ports/compose.go
+++ b/internal/application/ports/compose.go
@@ -26,6 +26,8 @@ func (c *ComposeFileSet) AllPaths() []string {
 // ComposeGenerator defines the interface for Docker Compose generation
 type ComposeGenerator interface {
 	Generate(services []*service.Service, infra infrastructure.InfrastructureRequirements) (*ComposeFileSet, error)
+	// GenerateWithTunnels generates compose with tunnel context for env_refs resolution
+	GenerateWithTunnels(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]TunnelContext) (*ComposeFileSet, error)
 }
 
 // EnvironmentResolver defines the interface for environment variable resolution

--- a/internal/application/ports/repository.go
+++ b/internal/application/ports/repository.go
@@ -1,6 +1,7 @@
 package ports
 
 import (
+	"github.com/vivekkundariya/grund/internal/domain/infrastructure"
 	"github.com/vivekkundariya/grund/internal/domain/service"
 )
 
@@ -10,6 +11,9 @@ type ServiceRepository interface {
 	FindByName(name service.ServiceName) (*service.Service, error)
 	FindAll() ([]*service.Service, error)
 	Save(svc *service.Service) error
+	// ExtractTunnelConfig extracts just the tunnel configuration without full service loading
+	// This is used to start infrastructure tunnels before loading services
+	ExtractTunnelConfig(name service.ServiceName) (*infrastructure.TunnelRequirement, error)
 }
 
 // ServiceRegistryRepository defines the interface for service registry

--- a/internal/infrastructure/generator/env_resolver.go
+++ b/internal/infrastructure/generator/env_resolver.go
@@ -325,7 +325,9 @@ func (r *EnvironmentResolverImpl) resolveTunnel(parts []string, context ports.En
 
 	tunnel, ok := context.Tunnel[tunnelName]
 	if !ok {
-		return "", fmt.Errorf("tunnel %s not found", tunnelName)
+		// Tunnel not available yet (e.g., during early validation before tunnels start)
+		// Return a placeholder that will be resolved later during compose generation
+		return fmt.Sprintf("TUNNEL_PENDING_%s_%s", strings.ToUpper(tunnelName), strings.ToUpper(property)), nil
 	}
 
 	switch property {


### PR DESCRIPTION
## Summary

- Start infrastructure tunnels **before** compose generation so `${tunnel.<name>.url}` placeholders resolve correctly
- Add `GenerateWithTunnels` method to inject tunnel context during compose generation
- Add `ExtractTunnelConfig` for lightweight tunnel config extraction without full service loading
- Make tunnel resolution graceful (returns placeholder when tunnel not available during early validation)
- Fix LocalStack health check to be generic instead of SQS-specific

## Documentation Updates

- Updated `architecture.md` with TunnelManager interface and data flow
- Updated `cli-commands.md` with tunnel startup step
- Added tunnel provider guide to `adding-new-infrastructure.md`

## Test plan

- [x] Tested end-to-end with S3 presigned URLs through cloudflared tunnel
- [x] Verified tunnel URL resolves in `env_refs` before service starts
- [ ] Run `make test` to verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)