### PR TITLE
fix: Auto-provision PostgreSQL databases for all services

### DIFF
--- a/internal/domain/infrastructure/infrastructure.go
+++ b/internal/domain/infrastructure/infrastructure.go
@@ -39,7 +39,15 @@ func (r *InfrastructureRequirements) Has(infraType string) bool {
 
 // PostgresConfig represents PostgreSQL configuration
 type PostgresConfig struct {
-	Database   string
+	Database   string             // Primary database (created by Docker via POSTGRES_DB)
+	Migrations string             // Migrations path for primary database
+	Seed       string             // Seed path for primary database
+	Databases  []PostgresDatabase // Additional databases from other services
+}
+
+// PostgresDatabase represents a single PostgreSQL database
+type PostgresDatabase struct {
+	Name       string
 	Migrations string
 	Seed       string
 }
@@ -118,11 +126,29 @@ func Aggregate(requirements ...InfrastructureRequirements) InfrastructureRequire
 	seenQueues := make(map[string]bool)
 	seenTopics := make(map[string]bool)
 	seenBuckets := make(map[string]bool)
+	seenDatabases := make(map[string]bool)
 
 	for _, req := range requirements {
-		// Single-instance: first config wins, all services share one container
-		if req.Postgres != nil && aggregated.Postgres == nil {
-			aggregated.Postgres = req.Postgres
+		// PostgreSQL: aggregate all databases from all services
+		if req.Postgres != nil {
+			if aggregated.Postgres == nil {
+				// First Postgres config becomes the primary
+				aggregated.Postgres = &PostgresConfig{
+					Database:   req.Postgres.Database,
+					Migrations: req.Postgres.Migrations,
+					Seed:       req.Postgres.Seed,
+					Databases:  []PostgresDatabase{},
+				}
+				seenDatabases[req.Postgres.Database] = true
+			} else if !seenDatabases[req.Postgres.Database] {
+				// Additional databases get added to the list
+				aggregated.Postgres.Databases = append(aggregated.Postgres.Databases, PostgresDatabase{
+					Name:       req.Postgres.Database,
+					Migrations: req.Postgres.Migrations,
+					Seed:       req.Postgres.Seed,
+				})
+				seenDatabases[req.Postgres.Database] = true
+			}
 		}
 		if req.MongoDB != nil && aggregated.MongoDB == nil {
 			aggregated.MongoDB = req.MongoDB

--- a/internal/infrastructure/docker/postgres_provisioner.go
+++ b/internal/infrastructure/docker/postgres_provisioner.go
@@ -3,9 +3,12 @@ package docker
 import (
 	"context"
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/vivekkundariya/grund/internal/application/ports"
 	"github.com/vivekkundariya/grund/internal/domain/infrastructure"
+	"github.com/vivekkundariya/grund/internal/ui"
 )
 
 // PostgresProvisioner implements infrastructure provisioning for PostgreSQL
@@ -16,11 +19,53 @@ func NewPostgresProvisioner() ports.InfrastructureProvisioner {
 	return &PostgresProvisioner{}
 }
 
-// ProvisionPostgres provisions PostgreSQL
+// ProvisionPostgres provisions PostgreSQL databases
 func (p *PostgresProvisioner) ProvisionPostgres(ctx context.Context, config *infrastructure.PostgresConfig) error {
-	// PostgreSQL is started via docker-compose, so provisioning here
-	// mainly involves running migrations and seeding if needed
+	if config == nil {
+		return nil
+	}
+
+	// Primary database is created by Docker via POSTGRES_DB env var
+	// We only need to create additional databases
+	for _, db := range config.Databases {
+		if err := p.createDatabase(ctx, db.Name); err != nil {
+			return fmt.Errorf("failed to create database %s: %w", db.Name, err)
+		}
+		ui.SubStep("postgres: %s ✓", db.Name)
+	}
+
 	// TODO: Implement migration and seeding logic
+	// if config.Migrations != "" {
+	//     if err := p.runMigrations(ctx, config.Database, config.Migrations); err != nil {
+	//         return fmt.Errorf("failed to run migrations: %w", err)
+	//     }
+	// }
+
+	return nil
+}
+
+// createDatabase creates a PostgreSQL database if it doesn't exist
+func (p *PostgresProvisioner) createDatabase(ctx context.Context, dbName string) error {
+	// Check if database already exists
+	checkCmd := exec.CommandContext(ctx, "docker", "exec", "grund-postgres",
+		"psql", "-U", "postgres", "-tAc",
+		fmt.Sprintf("SELECT 1 FROM pg_database WHERE datname='%s'", dbName))
+
+	output, err := checkCmd.Output()
+	if err == nil && strings.TrimSpace(string(output)) == "1" {
+		// Database already exists
+		return nil
+	}
+
+	// Create the database
+	createCmd := exec.CommandContext(ctx, "docker", "exec", "grund-postgres",
+		"psql", "-U", "postgres", "-c",
+		fmt.Sprintf("CREATE DATABASE %s", dbName))
+
+	if output, err := createCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("create database failed: %s: %w", string(output), err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Fix PostgreSQL database provisioning when multiple services need different databases.

## Problem

When multiple services require PostgreSQL with different database names:
- Service A needs `user_db`
- Service B needs `order_db`

Only the first database was created (via `POSTGRES_DB` env var). Other services would fail to connect.

## Solution

- Track all required databases during infrastructure aggregation
- Create additional databases via `docker exec` after the PostgreSQL container is healthy
- Primary database still created by Docker (efficient)
- Additional databases created by provisioner (flexible)

## Changes

- `internal/domain/infrastructure/infrastructure.go`:
  - Add `PostgresDatabase` struct
  - Add `Databases []PostgresDatabase` to `PostgresConfig`
  - Update `Aggregate()` to collect databases from all services

- `internal/infrastructure/docker/postgres_provisioner.go`:
  - Implement `createDatabase()` to create databases via `docker exec`
  - Check if database exists before creating (idempotent)

## Test Plan

- [x] All existing tests pass
- [x] Manual test: `grund up` with multi-service PostgreSQL setup

Fixes #32

🤖 Generated with [Claude Code](https://claude.ai/code)