### PR TITLE
fix: Remove -v shorthand from 'grund reset --volumes'

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ env_refs:
 | `grund status` | Show running services and their status |
 | `grund logs [service...]` | View service logs |
 | `grund restart <service>` | Restart a specific service |
-| `grund reset [-v]` | Stop services and optionally clean up volumes |
+| `grund reset [--volumes]` | Stop services and optionally clean up volumes |
 | `grund init` | Interactive setup wizard |
 | `grund config show [service]` | Show configuration and settings |
 | `grund service init` | Initialize `grund.yaml` in current directory |
@@ -389,7 +389,7 @@ flowchart TD
     J -->|Yes| K["Run: grund reset"]
 
     J -->|No| L{LocalStack<br/>issues?}
-    L -->|Yes| M["Run: grund reset -v"]
+    L -->|Yes| M["Run: grund reset --volumes"]
 
     L -->|No| N["Run: grund status"]
 
@@ -469,7 +469,7 @@ grund status
 
 If issues persist:
 ```bash
-grund reset -v
+grund reset --volumes
 grund up <service>
 ```
 

--- a/docs/wiki/cli-commands.md
+++ b/docs/wiki/cli-commands.md
@@ -237,10 +237,10 @@ grund reset [flags]
 > Using `--volumes` will **permanently delete** all database data. This cannot be undone!
 
 **Flags:**
-| Flag | Short | Description |
-|------|-------|-------------|
-| `--volumes` | `-v` | Remove named volumes (database data will be lost) |
-| `--images` | | Remove locally built images |
+| Flag | Description |
+|------|-------------|
+| `--volumes` | Remove named volumes (database data will be lost) |
+| `--images` | Remove locally built images |
 
 **Examples:**
 ```bash
@@ -248,10 +248,10 @@ grund reset [flags]
 grund reset
 
 # Stop and remove volumes (fresh start, loses all data)
-grund reset -v
+grund reset --volumes
 
 # Full cleanup: stop, remove volumes and images
-grund reset -v --images
+grund reset --volumes --images
 ```
 
 ---

--- a/internal/cli/reset.go
+++ b/internal/cli/reset.go
@@ -22,8 +22,8 @@ var resetCmd = &cobra.Command{
 
 Examples:
   grund reset              # Stop all services
-  grund reset -v           # Stop and remove volumes (database data)
-  grund reset -v --images  # Stop, remove volumes and images (full cleanup)`,
+  grund reset --volumes    # Stop and remove volumes (database data)
+  grund reset --volumes --images  # Stop, remove volumes and images (full cleanup)`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Discover compose files
 		fileSet, err := docker.DiscoverComposeFiles()
@@ -71,6 +71,6 @@ Examples:
 }
 
 func init() {
-	resetCmd.Flags().BoolVarP(&resetVolumes, "volumes", "v", false, "Remove named volumes (database data will be lost)")
+	resetCmd.Flags().BoolVar(&resetVolumes, "volumes", false, "Remove named volumes (database data will be lost)")
 	resetCmd.Flags().BoolVar(&resetImages, "images", false, "Remove locally built images")
 }


### PR DESCRIPTION
## Summary

Fix flag conflict where `-v` was used as shorthand for both `--verbose` (global) and `--volumes` (reset command).

## Problem

Running `grund reset -v` was ambiguous:
- Did the user mean `--verbose` (debug output)?
- Or `--volumes` (delete database data)?

## Solution

Remove the `-v` shorthand from `--volumes`. Since this flag permanently deletes database data, requiring the full `--volumes` flag is:
1. **Safer** - prevents accidental data loss
2. **Clearer** - no ambiguity with `--verbose`
3. **More explicit** - destructive operations should be intentional

## Changes

- `internal/cli/reset.go`: Change `BoolVarP` to `BoolVar` (remove shorthand)
- `README.md`: Update examples and command reference
- `docs/wiki/cli-commands.md`: Update flag table and examples

## Before/After

```bash
# Before (ambiguous)
grund reset -v      # Which -v?

# After (explicit)
grund reset --volumes    # Clear intent
grund -v reset           # Verbose mode
```

Fixes #33

🤖 Generated with [Claude Code](https://claude.ai/code)