### PR TITLE
fix: Fetch actual SQS/SNS URLs and ARNs from LocalStack

### DIFF
--- a/internal/application/commands/up_command.go
+++ b/internal/application/commands/up_command.go
@@ -119,11 +119,22 @@ func (h *UpCommandHandler) Handle(ctx context.Context, cmd UpCommand) error {
 	if infraReqs.SQS != nil || infraReqs.SNS != nil || infraReqs.S3 != nil {
 		ui.Step("Provisioning AWS resources in LocalStack...")
 	}
-	if err := h.provisionInfrastructure(ctx, infraReqs); err != nil {
+	awsResources, err := h.provisionInfrastructure(ctx, infraReqs)
+	if err != nil {
 		return fmt.Errorf("failed to provision infrastructure: %w", err)
 	}
 	if infraReqs.SQS != nil || infraReqs.SNS != nil || infraReqs.S3 != nil {
 		ui.Successf("AWS resources provisioned")
+	}
+
+	// 8.5. Regenerate service compose files with real AWS resource URLs
+	// Now that we have actual URLs/ARNs from LocalStack, update the compose files
+	if awsResources != nil {
+		ui.Step("Updating service configuration with actual AWS resource URLs...")
+		if err := h.regenerateComposeWithAWSResources(services, infraReqs, tunnelContext, awsResources); err != nil {
+			return fmt.Errorf("failed to update compose with AWS resources: %w", err)
+		}
+		ui.Successf("Service configuration updated")
 	}
 
 	// 9. Start services in parallel (no ordering enforced)
@@ -223,28 +234,30 @@ func (h *UpCommandHandler) aggregateInfrastructure(services []*service.Service) 
 	return infrastructure.Aggregate(reqs...)
 }
 
-func (h *UpCommandHandler) provisionInfrastructure(ctx context.Context, req infrastructure.InfrastructureRequirements) error {
+func (h *UpCommandHandler) provisionInfrastructure(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error) {
 	if req.Postgres != nil {
 		if err := h.provisioner.ProvisionPostgres(ctx, req.Postgres); err != nil {
-			return fmt.Errorf("postgres: %w", err)
+			return nil, fmt.Errorf("postgres: %w", err)
 		}
 	}
 	if req.MongoDB != nil {
 		if err := h.provisioner.ProvisionMongoDB(ctx, req.MongoDB); err != nil {
-			return fmt.Errorf("mongodb: %w", err)
+			return nil, fmt.Errorf("mongodb: %w", err)
 		}
 	}
 	if req.Redis != nil {
 		if err := h.provisioner.ProvisionRedis(ctx, req.Redis); err != nil {
-			return fmt.Errorf("redis: %w", err)
+			return nil, fmt.Errorf("redis: %w", err)
 		}
 	}
 	if req.SQS != nil || req.SNS != nil || req.S3 != nil {
-		if err := h.provisioner.ProvisionLocalStack(ctx, req); err != nil {
-			return fmt.Errorf("localstack: %w", err)
+		awsResources, err := h.provisioner.ProvisionLocalStack(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("localstack: %w", err)
 		}
+		return awsResources, nil
 	}
-	return nil
+	return nil, nil
 }
 
 func (h *UpCommandHandler) generateCompose(services []*service.Service, req infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext) error {
@@ -267,6 +280,18 @@ func (h *UpCommandHandler) generateCompose(services []*service.Service, req infr
 
 func (h *UpCommandHandler) startServices(ctx context.Context, order []service.ServiceName) error {
 	return h.orchestrator.StartServices(ctx, order)
+}
+
+// regenerateComposeWithAWSResources regenerates service compose files with actual AWS resource URLs/ARNs
+func (h *UpCommandHandler) regenerateComposeWithAWSResources(services []*service.Service, req infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext, awsResources *ports.ProvisionedAWSResources) error {
+	fileSet, err := h.composeGenerator.GenerateWithAWSResources(services, req, tunnelCtx, awsResources)
+	if err != nil {
+		return err
+	}
+
+	// Update orchestrator with the regenerated compose files
+	h.orchestrator.SetComposeFiles(fileSet.AllPaths())
+	return nil
 }
 
 // startTunnels starts tunnels based on the tunnel requirement and returns tunnel context

--- a/internal/application/commands/up_command_test.go
+++ b/internal/application/commands/up_command_test.go
@@ -118,9 +118,35 @@ func (m *mockProvisioner) ProvisionRedis(ctx context.Context, config *infrastruc
 	return m.provisionErr
 }
 
-func (m *mockProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) error {
+func (m *mockProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error) {
 	m.localstackCalls = append(m.localstackCalls, req)
-	return m.provisionErr
+	if m.provisionErr != nil {
+		return nil, m.provisionErr
+	}
+	// Return mock provisioned resources
+	result := &ports.ProvisionedAWSResources{
+		SQS: make(map[string]ports.ProvisionedQueue),
+		SNS: make(map[string]ports.ProvisionedTopic),
+		S3:  make(map[string]ports.ProvisionedBucket),
+	}
+	if req.SQS != nil {
+		for _, q := range req.SQS.Queues {
+			result.SQS[q.Name] = ports.ProvisionedQueue{
+				Name: q.Name,
+				URL:  "http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/" + q.Name,
+				ARN:  "arn:aws:sqs:us-east-1:000000000000:" + q.Name,
+			}
+		}
+	}
+	if req.SNS != nil {
+		for _, t := range req.SNS.Topics {
+			result.SNS[t.Name] = ports.ProvisionedTopic{
+				Name: t.Name,
+				ARN:  "arn:aws:sns:us-east-1:000000000000:" + t.Name,
+			}
+		}
+	}
+	return result, nil
 }
 
 type mockComposeGenerator struct {
@@ -138,6 +164,10 @@ func (m *mockComposeGenerator) Generate(services []*service.Service, infra infra
 }
 
 func (m *mockComposeGenerator) GenerateWithTunnels(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext) (*ports.ComposeFileSet, error) {
+	return m.Generate(services, infra)
+}
+
+func (m *mockComposeGenerator) GenerateWithAWSResources(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext, awsResources *ports.ProvisionedAWSResources) (*ports.ComposeFileSet, error) {
 	return m.Generate(services, infra)
 }
 

--- a/internal/application/ports/compose.go
+++ b/internal/application/ports/compose.go
@@ -28,6 +28,8 @@ type ComposeGenerator interface {
 	Generate(services []*service.Service, infra infrastructure.InfrastructureRequirements) (*ComposeFileSet, error)
 	// GenerateWithTunnels generates compose with tunnel context for env resolution
 	GenerateWithTunnels(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]TunnelContext) (*ComposeFileSet, error)
+	// GenerateWithAWSResources generates compose with actual AWS resource URLs/ARNs from LocalStack
+	GenerateWithAWSResources(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]TunnelContext, awsResources *ProvisionedAWSResources) (*ComposeFileSet, error)
 }
 
 // EnvironmentResolver defines the interface for environment variable resolution

--- a/internal/application/ports/orchestrator.go
+++ b/internal/application/ports/orchestrator.go
@@ -39,7 +39,35 @@ type InfrastructureProvisioner interface {
 	ProvisionPostgres(ctx context.Context, config *infrastructure.PostgresConfig) error
 	ProvisionMongoDB(ctx context.Context, config *infrastructure.MongoDBConfig) error
 	ProvisionRedis(ctx context.Context, config *infrastructure.RedisConfig) error
-	ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) error
+	ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ProvisionedAWSResources, error)
+}
+
+// ProvisionedAWSResources contains the actual resource details from LocalStack
+type ProvisionedAWSResources struct {
+	SQS map[string]ProvisionedQueue // queue name -> details
+	SNS map[string]ProvisionedTopic // topic name -> details
+	S3  map[string]ProvisionedBucket // bucket name -> details
+}
+
+// ProvisionedQueue contains actual SQS queue details from LocalStack
+type ProvisionedQueue struct {
+	Name   string
+	URL    string
+	ARN    string
+	DLQURL string // Empty if no DLQ
+	DLQARN string // Empty if no DLQ
+}
+
+// ProvisionedTopic contains actual SNS topic details from LocalStack
+type ProvisionedTopic struct {
+	Name string
+	ARN  string
+}
+
+// ProvisionedBucket contains actual S3 bucket details from LocalStack
+type ProvisionedBucket struct {
+	Name string
+	URL  string
 }
 
 // HealthChecker defines the interface for health checking

--- a/internal/infrastructure/aws/provisioner.go
+++ b/internal/infrastructure/aws/provisioner.go
@@ -45,12 +45,12 @@ func (p *LocalStackProvisioner) ProvisionRedis(ctx context.Context, config *infr
 }
 
 // ProvisionLocalStack provisions AWS resources in LocalStack
-func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) error {
+func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error) {
 	ui.Debug("Connecting to LocalStack at %s", p.endpoint)
 
 	cfg, err := createLocalStackConfig(p.endpoint)
 	if err != nil {
-		return fmt.Errorf("failed to create AWS config: %w", err)
+		return nil, fmt.Errorf("failed to create AWS config: %w", err)
 	}
 
 	sqsClient := sqs.NewFromConfig(cfg)
@@ -59,25 +59,43 @@ func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req inf
 		o.UsePathStyle = true // Required for LocalStack and bucket names with dots
 	})
 
+	// Initialize result with provisioned resource details
+	result := &ports.ProvisionedAWSResources{
+		SQS: make(map[string]ports.ProvisionedQueue),
+		SNS: make(map[string]ports.ProvisionedTopic),
+		S3:  make(map[string]ports.ProvisionedBucket),
+	}
+
 	queueArns := make(map[string]string)
 
 	// Create SQS Queues
 	if req.SQS != nil {
 		for _, queue := range req.SQS.Queues {
+			var dlqURL, dlqARN string
+
 			if queue.DLQ {
 				dlqName := queue.Name + "-dlq"
 				if existingURL, exists := getExistingQueueURL(ctx, sqsClient, dlqName); exists {
 					ui.Infof("SQS DLQ already exists: %s", dlqName)
-					_ = existingURL // DLQ URL not needed for ARN tracking
+					dlqURL = existingURL
 				} else {
 					ui.SubStep("Creating SQS DLQ: %s", dlqName)
-					_, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+					dlqResult, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
 						QueueName: aws.String(dlqName),
 					})
 					if err != nil {
-						return fmt.Errorf("failed to create DLQ %s: %w", dlqName, err)
+						return nil, fmt.Errorf("failed to create DLQ %s: %w", dlqName, err)
 					}
+					dlqURL = *dlqResult.QueueUrl
 					ui.Successf("Created SQS DLQ: %s", dlqName)
+				}
+				// Get DLQ ARN
+				dlqAttrs, _ := sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+					QueueUrl:       aws.String(dlqURL),
+					AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameQueueArn},
+				})
+				if dlqAttrs != nil && dlqAttrs.Attributes != nil {
+					dlqARN = dlqAttrs.Attributes["QueueArn"]
 				}
 			}
 
@@ -87,23 +105,34 @@ func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req inf
 				queueURL = existingURL
 			} else {
 				ui.SubStep("Creating SQS queue: %s", queue.Name)
-				result, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
+				createResult, err := sqsClient.CreateQueue(ctx, &sqs.CreateQueueInput{
 					QueueName: aws.String(queue.Name),
 				})
 				if err != nil {
-					return fmt.Errorf("failed to create queue %s: %w", queue.Name, err)
+					return nil, fmt.Errorf("failed to create queue %s: %w", queue.Name, err)
 				}
-				queueURL = *result.QueueUrl
+				queueURL = *createResult.QueueUrl
 				ui.Successf("Created SQS queue: %s", queue.Name)
 			}
 
-			// Get queue ARN for SNS subscription
+			// Get queue ARN
+			var queueARN string
 			attrs, _ := sqsClient.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
 				QueueUrl:       aws.String(queueURL),
 				AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameQueueArn},
 			})
-			if attrs.Attributes != nil {
-				queueArns[queue.Name] = attrs.Attributes["QueueArn"]
+			if attrs != nil && attrs.Attributes != nil {
+				queueARN = attrs.Attributes["QueueArn"]
+				queueArns[queue.Name] = queueARN
+			}
+
+			// Store provisioned queue details
+			result.SQS[queue.Name] = ports.ProvisionedQueue{
+				Name:   queue.Name,
+				URL:    queueURL,
+				ARN:    queueARN,
+				DLQURL: dlqURL,
+				DLQARN: dlqARN,
 			}
 		}
 	}
@@ -135,9 +164,15 @@ func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req inf
 				Name: aws.String(topic.Name),
 			})
 			if err != nil {
-				return fmt.Errorf("failed to create topic %s: %w", topic.Name, err)
+				return nil, fmt.Errorf("failed to create topic %s: %w", topic.Name, err)
 			}
 			ui.Successf("SNS topic ready: %s", topic.Name)
+
+			// Store provisioned topic details
+			result.SNS[topic.Name] = ports.ProvisionedTopic{
+				Name: topic.Name,
+				ARN:  *topicResult.TopicArn,
+			}
 
 			// Subscribe endpoints to topic
 			for _, sub := range topic.Subscriptions {
@@ -147,7 +182,7 @@ func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req inf
 					envContext,
 				)
 				if err != nil {
-					return fmt.Errorf("failed to resolve endpoint %s: %w", sub.Endpoint, err)
+					return nil, fmt.Errorf("failed to resolve endpoint %s: %w", sub.Endpoint, err)
 				}
 				endpoint := resolved["endpoint"]
 
@@ -158,7 +193,7 @@ func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req inf
 					Endpoint: aws.String(endpoint),
 				})
 				if err != nil {
-					return fmt.Errorf("failed to subscribe %s to %s: %w", endpoint, topic.Name, err)
+					return nil, fmt.Errorf("failed to subscribe %s to %s: %w", endpoint, topic.Name, err)
 				}
 
 				// Set subscription attributes (FilterPolicy, FilterPolicyScope, etc.)
@@ -170,7 +205,7 @@ func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req inf
 						AttributeValue:  aws.String(attrValue),
 					})
 					if err != nil {
-						return fmt.Errorf("failed to set attribute %s on subscription: %w", attrName, err)
+						return nil, fmt.Errorf("failed to set attribute %s on subscription: %w", attrName, err)
 					}
 				}
 			}
@@ -188,14 +223,20 @@ func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req inf
 					Bucket: aws.String(bucket.Name),
 				})
 				if err != nil {
-					return fmt.Errorf("failed to create bucket %s: %w", bucket.Name, err)
+					return nil, fmt.Errorf("failed to create bucket %s: %w", bucket.Name, err)
 				}
 				ui.Successf("Created S3 bucket: %s", bucket.Name)
+			}
+
+			// Store provisioned bucket details (use path-style URL for LocalStack)
+			result.S3[bucket.Name] = ports.ProvisionedBucket{
+				Name: bucket.Name,
+				URL:  fmt.Sprintf("%s/%s", p.endpoint, bucket.Name),
 			}
 		}
 	}
 
-	return nil
+	return result, nil
 }
 
 // getExistingQueueURL checks if a queue already exists and returns its URL

--- a/internal/infrastructure/docker/infrastructure_provisioner.go
+++ b/internal/infrastructure/docker/infrastructure_provisioner.go
@@ -86,12 +86,12 @@ func (c *CompositeInfrastructureProvisioner) ProvisionRedis(ctx context.Context,
 }
 
 // ProvisionLocalStack delegates to LocalStack provisioner
-func (c *CompositeInfrastructureProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) error {
+func (c *CompositeInfrastructureProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error) {
 	var lastErr error
 	for _, p := range c.provisioners {
-		err := p.ProvisionLocalStack(ctx, req)
+		result, err := p.ProvisionLocalStack(ctx, req)
 		if err == nil {
-			return nil
+			return result, nil
 		}
 		if isNotSupportedError(err) {
 			continue
@@ -99,9 +99,9 @@ func (c *CompositeInfrastructureProvisioner) ProvisionLocalStack(ctx context.Con
 		lastErr = err
 	}
 	if lastErr != nil {
-		return fmt.Errorf("localstack provisioning failed: %w", lastErr)
+		return nil, fmt.Errorf("localstack provisioning failed: %w", lastErr)
 	}
-	return fmt.Errorf("no provisioner supports localstack")
+	return nil, fmt.Errorf("no provisioner supports localstack")
 }
 
 // isNotSupportedError checks if an error indicates the provisioner doesn't support this type

--- a/internal/infrastructure/docker/mongodb_provisioner.go
+++ b/internal/infrastructure/docker/mongodb_provisioner.go
@@ -35,6 +35,6 @@ func (m *MongoDBProvisioner) ProvisionRedis(ctx context.Context, config *infrast
 }
 
 // ProvisionLocalStack not applicable
-func (m *MongoDBProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) error {
-	return fmt.Errorf("localstack provisioning not supported by mongodb provisioner")
+func (m *MongoDBProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error) {
+	return nil, fmt.Errorf("localstack provisioning not supported by mongodb provisioner")
 }

--- a/internal/infrastructure/docker/postgres_provisioner.go
+++ b/internal/infrastructure/docker/postgres_provisioner.go
@@ -80,6 +80,6 @@ func (p *PostgresProvisioner) ProvisionRedis(ctx context.Context, config *infras
 }
 
 // ProvisionLocalStack not applicable
-func (p *PostgresProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) error {
-	return fmt.Errorf("localstack provisioning not supported by postgres provisioner")
+func (p *PostgresProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error) {
+	return nil, fmt.Errorf("localstack provisioning not supported by postgres provisioner")
 }

--- a/internal/infrastructure/docker/redis_provisioner.go
+++ b/internal/infrastructure/docker/redis_provisioner.go
@@ -34,6 +34,6 @@ func (r *RedisProvisioner) ProvisionMongoDB(ctx context.Context, config *infrast
 }
 
 // ProvisionLocalStack not applicable
-func (r *RedisProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) error {
-	return fmt.Errorf("localstack provisioning not supported by redis provisioner")
+func (r *RedisProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error) {
+	return nil, fmt.Errorf("localstack provisioning not supported by redis provisioner")
 }

--- a/internal/infrastructure/generator/compose_generator.go
+++ b/internal/infrastructure/generator/compose_generator.go
@@ -244,6 +244,44 @@ func (g *ComposeGeneratorImpl) GenerateWithTunnels(services []*service.Service, 
 	return fileSet, nil
 }
 
+// GenerateWithAWSResources generates compose files with actual AWS resource URLs/ARNs from LocalStack
+// This is called after provisioning to update service configs with real URLs instead of hardcoded ones
+func (g *ComposeGeneratorImpl) GenerateWithAWSResources(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext, awsResources *ports.ProvisionedAWSResources) (*ports.ComposeFileSet, error) {
+	fileSet := &ports.ComposeFileSet{
+		ServicePaths: make(map[string]string),
+	}
+
+	// Discover existing compose files
+	g.discoverExistingComposeFiles(fileSet)
+
+	// Build environment context with actual AWS resource URLs
+	envContext := g.buildEnvironmentContextWithAWSResources(services, infra, awsResources)
+
+	// Inject tunnel context
+	if tunnelCtx != nil {
+		for name, tc := range tunnelCtx {
+			envContext.Tunnel[name] = tc
+		}
+	}
+
+	// Create port allocator
+	portAlloc := newPortAllocator()
+
+	// Don't regenerate infrastructure - only regenerate service compose files
+	// Infrastructure compose file stays the same
+
+	// Generate per-service compose files with real AWS URLs
+	for _, svc := range services {
+		svcPath, err := g.generateService(svc, envContext, portAlloc)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate compose for %s: %w", svc.Name, err)
+		}
+		fileSet.ServicePaths[svc.Name] = svcPath
+	}
+
+	return fileSet, nil
+}
+
 // discoverExistingComposeFiles scans tmpDir for existing compose files
 func (g *ComposeGeneratorImpl) discoverExistingComposeFiles(fileSet *ports.ComposeFileSet) {
 	// Check if tmp directory exists
@@ -519,7 +557,7 @@ func (g *ComposeGeneratorImpl) buildEnvironmentContext(services []*service.Servi
 		}
 	}
 
-	// Add SQS queue contexts
+	// Add SQS queue contexts (with placeholder URLs - will be updated after provisioning)
 	if infra.SQS != nil {
 		for _, queue := range infra.SQS.Queues {
 			ctx.SQS[queue.Name] = ports.QueueContext{
@@ -531,7 +569,7 @@ func (g *ComposeGeneratorImpl) buildEnvironmentContext(services []*service.Servi
 		}
 	}
 
-	// Add SNS topic contexts
+	// Add SNS topic contexts (with placeholder ARNs - will be updated after provisioning)
 	if infra.SNS != nil {
 		for _, topic := range infra.SNS.Topics {
 			ctx.SNS[topic.Name] = ports.TopicContext{
@@ -555,6 +593,83 @@ func (g *ComposeGeneratorImpl) buildEnvironmentContext(services []*service.Servi
 	for _, svc := range services {
 		ctx.Services[svc.Name] = ports.ServiceContext{
 			Host: svc.Name, // Container name in Docker network
+			Port: svc.Port.Value(),
+			Config: map[string]any{
+				"postgres.database": getServicePostgresDB(svc),
+				"mongodb.database":  getServiceMongoDB(svc),
+			},
+		}
+	}
+
+	return ctx
+}
+
+// buildEnvironmentContextWithAWSResources builds environment context using actual AWS resource URLs/ARNs
+func (g *ComposeGeneratorImpl) buildEnvironmentContextWithAWSResources(services []*service.Service, infra infrastructure.InfrastructureRequirements, awsResources *ports.ProvisionedAWSResources) ports.EnvironmentContext {
+	ctx := ports.NewDefaultEnvironmentContext()
+
+	// Add infrastructure contexts
+	if infra.Postgres != nil {
+		ctx.Infrastructure["postgres"] = ports.InfrastructureContext{
+			Host:     "postgres",
+			Port:     5432,
+			Database: infra.Postgres.Database,
+			Username: "postgres",
+			Password: "postgres",
+		}
+	}
+
+	if infra.MongoDB != nil {
+		ctx.Infrastructure["mongodb"] = ports.InfrastructureContext{
+			Host:     "mongodb",
+			Port:     27017,
+			Database: infra.MongoDB.Database,
+		}
+	}
+
+	if infra.Redis != nil {
+		ctx.Infrastructure["redis"] = ports.InfrastructureContext{
+			Host: "redis",
+			Port: 6379,
+		}
+	}
+
+	// Add SQS queue contexts with ACTUAL URLs from LocalStack
+	if awsResources != nil && awsResources.SQS != nil {
+		for name, queue := range awsResources.SQS {
+			ctx.SQS[name] = ports.QueueContext{
+				Name: queue.Name,
+				URL:  queue.URL,
+				ARN:  queue.ARN,
+				DLQ:  queue.DLQURL,
+			}
+		}
+	}
+
+	// Add SNS topic contexts with ACTUAL ARNs from LocalStack
+	if awsResources != nil && awsResources.SNS != nil {
+		for name, topic := range awsResources.SNS {
+			ctx.SNS[name] = ports.TopicContext{
+				Name: topic.Name,
+				ARN:  topic.ARN,
+			}
+		}
+	}
+
+	// Add S3 bucket contexts with ACTUAL URLs from LocalStack
+	if awsResources != nil && awsResources.S3 != nil {
+		for name, bucket := range awsResources.S3 {
+			ctx.S3[name] = ports.BucketContext{
+				Name: bucket.Name,
+				URL:  bucket.URL,
+			}
+		}
+	}
+
+	// Add service contexts
+	for _, svc := range services {
+		ctx.Services[svc.Name] = ports.ServiceContext{
+			Host: svc.Name,
 			Port: svc.Port.Value(),
 			Config: map[string]any{
 				"postgres.database": getServicePostgresDB(svc),

--- a/test/mocks/mocks.go
+++ b/test/mocks/mocks.go
@@ -128,7 +128,7 @@ type MockInfrastructureProvisioner struct {
 	ProvisionPostgresFunc   func(ctx context.Context, config *infrastructure.PostgresConfig) error
 	ProvisionMongoDBFunc    func(ctx context.Context, config *infrastructure.MongoDBConfig) error
 	ProvisionRedisFunc      func(ctx context.Context, config *infrastructure.RedisConfig) error
-	ProvisionLocalStackFunc func(ctx context.Context, req infrastructure.InfrastructureRequirements) error
+	ProvisionLocalStackFunc func(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error)
 
 	// Track calls
 	ProvisionPostgresCalls   []*infrastructure.PostgresConfig
@@ -161,17 +161,19 @@ func (m *MockInfrastructureProvisioner) ProvisionRedis(ctx context.Context, conf
 	return nil
 }
 
-func (m *MockInfrastructureProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) error {
+func (m *MockInfrastructureProvisioner) ProvisionLocalStack(ctx context.Context, req infrastructure.InfrastructureRequirements) (*ports.ProvisionedAWSResources, error) {
 	m.ProvisionLocalStackCalls = append(m.ProvisionLocalStackCalls, req)
 	if m.ProvisionLocalStackFunc != nil {
 		return m.ProvisionLocalStackFunc(ctx, req)
 	}
-	return nil
+	return nil, nil
 }
 
 // MockComposeGenerator is a mock implementation of ports.ComposeGenerator
 type MockComposeGenerator struct {
-	GenerateFunc func(services []*service.Service, infra infrastructure.InfrastructureRequirements) (string, error)
+	GenerateFunc             func(services []*service.Service, infra infrastructure.InfrastructureRequirements) (*ports.ComposeFileSet, error)
+	GenerateWithTunnelsFunc  func(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext) (*ports.ComposeFileSet, error)
+	GenerateWithAWSResourcesFunc func(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext, awsResources *ports.ProvisionedAWSResources) (*ports.ComposeFileSet, error)
 
 	// Track calls
 	GenerateCalls []struct {
@@ -180,7 +182,7 @@ type MockComposeGenerator struct {
 	}
 }
 
-func (m *MockComposeGenerator) Generate(services []*service.Service, infra infrastructure.InfrastructureRequirements) (string, error) {
+func (m *MockComposeGenerator) Generate(services []*service.Service, infra infrastructure.InfrastructureRequirements) (*ports.ComposeFileSet, error) {
 	m.GenerateCalls = append(m.GenerateCalls, struct {
 		Services []*service.Service
 		Infra    infrastructure.InfrastructureRequirements
@@ -188,7 +190,30 @@ func (m *MockComposeGenerator) Generate(services []*service.Service, infra infra
 	if m.GenerateFunc != nil {
 		return m.GenerateFunc(services, infra)
 	}
-	return "/tmp/docker-compose.generated.yaml", nil
+	return &ports.ComposeFileSet{
+		InfrastructurePath: "/tmp/infrastructure/docker-compose.yaml",
+		ServicePaths:       make(map[string]string),
+	}, nil
+}
+
+func (m *MockComposeGenerator) GenerateWithTunnels(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext) (*ports.ComposeFileSet, error) {
+	if m.GenerateWithTunnelsFunc != nil {
+		return m.GenerateWithTunnelsFunc(services, infra, tunnelCtx)
+	}
+	return &ports.ComposeFileSet{
+		InfrastructurePath: "/tmp/infrastructure/docker-compose.yaml",
+		ServicePaths:       make(map[string]string),
+	}, nil
+}
+
+func (m *MockComposeGenerator) GenerateWithAWSResources(services []*service.Service, infra infrastructure.InfrastructureRequirements, tunnelCtx map[string]ports.TunnelContext, awsResources *ports.ProvisionedAWSResources) (*ports.ComposeFileSet, error) {
+	if m.GenerateWithAWSResourcesFunc != nil {
+		return m.GenerateWithAWSResourcesFunc(services, infra, tunnelCtx, awsResources)
+	}
+	return &ports.ComposeFileSet{
+		InfrastructurePath: "/tmp/infrastructure/docker-compose.yaml",
+		ServicePaths:       make(map[string]string),
+	}, nil
 }
 
 // MockHealthChecker is a mock implementation of ports.HealthChecker


### PR DESCRIPTION
## Summary

Fixes #40 - SQS queue URLs were hardcoded instead of fetched from LocalStack.

### Problem

Queue URLs were constructed using a hardcoded pattern:
```
http://localstack:4566/000000000000/queue-name
```

But LocalStack returns URLs in SQS standard format:
```
http://sqs.us-east-1.localhost.localstack.cloud:4566/000000000000/queue-name
```

### Solution

- Add `ProvisionedAWSResources` struct to capture actual resource details from LocalStack
- Update `ProvisionLocalStack` to return:
  - Queue URLs (from `CreateQueue`/`GetQueueUrl`)
  - Queue ARNs (from `GetQueueAttributes`)
  - DLQ URLs and ARNs
  - Topic ARNs (from `CreateTopic`)
- Add `GenerateWithAWSResources` to regenerate compose files after provisioning
- Update the `up` command flow:
  1. Generate initial compose (for infrastructure containers)
  2. Start infrastructure containers
  3. Provision LocalStack resources (get actual URLs)
  4. **Regenerate service compose files with real URLs**
  5. Start services

### Files Changed

- `internal/application/ports/orchestrator.go` - Add `ProvisionedAWSResources` struct
- `internal/application/ports/compose.go` - Add `GenerateWithAWSResources` interface method
- `internal/infrastructure/aws/provisioner.go` - Return actual URLs/ARNs
- `internal/infrastructure/generator/compose_generator.go` - Implement new generation method
- `internal/application/commands/up_command.go` - Update flow to regenerate after provisioning
- Various provisioner and mock updates

## Test plan

- [x] All existing tests pass
- [x] Run `grund up service` and verify queue URLs match LocalStack format
- [x] Verify `docker exec grund-localstack awslocal sqs get-queue-url --queue-name <name>` matches env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)