### PR TITLE
fix: Upgrade requests to 2.32.4 for security vulnerabilities

### DIFF
--- a/docs/demo/order-service/requirements.txt
+++ b/docs/demo/order-service/requirements.txt
@@ -1,4 +1,4 @@
 flask==3.0.0
 psycopg2-binary==2.9.9
 boto3==1.34.0
-requests==2.31.0
+requests==2.32.4


### PR DESCRIPTION
## Summary
- Upgrades `requests` from 2.31.0 to 2.32.4 in `docs/demo/order-service/requirements.txt`
- Resolves **both** open Dependabot alerts:
  - **#1** (Medium): `Session` object does not verify requests after `verify=False`
  - **#2** (Medium): `.netrc` credentials leak via malicious URLs

## Test plan
- [ ] Verify `docs/demo/order-service` still works with updated `requests` version
- [ ] Confirm Dependabot alerts are auto-dismissed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)