### PR TITLE
chore: Bump version to 0.4.0

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -39,7 +39,7 @@ Configuration:
   grund config show           View configuration
 
 Documentation: https://github.com/Saturn-Fintech/grund`,
-	Version: "0.3.0",
+	Version: "0.4.0",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Set verbose mode on logger
 		ui.SetVerbose(verbose)


### PR DESCRIPTION
## Summary
- Bumps `grund --version` from 0.3.0 to 0.4.0

## Test plan
- [ ] Run `grund --version` and confirm it outputs `0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)