### PR TITLE
feat: S3 CORS config and tunnel process persistence

### DIFF
--- a/internal/application/commands/down_command.go
+++ b/internal/application/commands/down_command.go
@@ -14,10 +14,11 @@ type DownCommand struct{}
 
 // DownCommandHandler handles the down command
 type DownCommandHandler struct {
-	serviceRepo  ports.ServiceRepository
-	registryRepo ports.ServiceRegistryRepository
-	orchestrator ports.ContainerOrchestrator
-	hookExecutor ports.HookExecutor
+	serviceRepo   ports.ServiceRepository
+	registryRepo  ports.ServiceRegistryRepository
+	orchestrator  ports.ContainerOrchestrator
+	hookExecutor  ports.HookExecutor
+	tunnelManager ports.TunnelManager
 }
 
 // NewDownCommandHandler creates a new down command handler
@@ -26,12 +27,14 @@ func NewDownCommandHandler(
 	registryRepo ports.ServiceRegistryRepository,
 	orchestrator ports.ContainerOrchestrator,
 	hookExecutor ports.HookExecutor,
+	tunnelManager ports.TunnelManager,
 ) *DownCommandHandler {
 	return &DownCommandHandler{
-		serviceRepo:  serviceRepo,
-		registryRepo: registryRepo,
-		orchestrator: orchestrator,
-		hookExecutor: hookExecutor,
+		serviceRepo:   serviceRepo,
+		registryRepo:  registryRepo,
+		orchestrator:  orchestrator,
+		hookExecutor:  hookExecutor,
+		tunnelManager: tunnelManager,
 	}
 }
 
@@ -71,6 +74,11 @@ func (h *DownCommandHandler) Handle(ctx context.Context, cmd DownCommand) error 
 	// Stop containers
 	if err := h.orchestrator.StopServices(ctx); err != nil {
 		return err
+	}
+
+	// Stop tunnels (kills processes, removes PID files)
+	if err := h.tunnelManager.StopAll(); err != nil {
+		ui.Warnf("Failed to stop tunnels: %v", err)
 	}
 
 	// Run post_down hooks

--- a/internal/application/commands/down_command_test.go
+++ b/internal/application/commands/down_command_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/Saturn-Fintech/grund/internal/application/ports"
+	"github.com/Saturn-Fintech/grund/internal/config"
 	"github.com/Saturn-Fintech/grund/internal/domain/infrastructure"
 	"github.com/Saturn-Fintech/grund/internal/domain/service"
 )
@@ -86,9 +87,30 @@ func (m *mockDownHookExecutor) ExecuteAll(ctx context.Context, hooks []service.H
 	return nil
 }
 
+type mockDownTunnelManager struct {
+	stopCalls int
+}
+
+func (m *mockDownTunnelManager) ValidateConfig(cfg *config.TunnelConfig) error {
+	return nil
+}
+
+func (m *mockDownTunnelManager) StartAll(ctx context.Context, cfg *config.TunnelConfig, targets []ports.ResolvedTunnelTarget) ([]ports.TunnelInfo, error) {
+	return nil, nil
+}
+
+func (m *mockDownTunnelManager) StopAll() error {
+	m.stopCalls++
+	return nil
+}
+
+func (m *mockDownTunnelManager) GetTunnels() map[string]ports.TunnelInfo {
+	return nil
+}
+
 func TestDownCommandHandler_Handle_Success(t *testing.T) {
 	orchestrator := &mockDownOrchestrator{}
-	handler := NewDownCommandHandler(&mockDownServiceRepo{}, &mockDownRegistryRepo{}, orchestrator, &mockDownHookExecutor{})
+	handler := NewDownCommandHandler(&mockDownServiceRepo{}, &mockDownRegistryRepo{}, orchestrator, &mockDownHookExecutor{}, &mockDownTunnelManager{})
 
 	cmd := DownCommand{}
 
@@ -106,7 +128,7 @@ func TestDownCommandHandler_Handle_OrchestratorFails(t *testing.T) {
 	orchestrator := &mockDownOrchestrator{
 		stopErr: fmt.Errorf("docker compose down failed"),
 	}
-	handler := NewDownCommandHandler(&mockDownServiceRepo{}, &mockDownRegistryRepo{}, orchestrator, &mockDownHookExecutor{})
+	handler := NewDownCommandHandler(&mockDownServiceRepo{}, &mockDownRegistryRepo{}, orchestrator, &mockDownHookExecutor{}, &mockDownTunnelManager{})
 
 	cmd := DownCommand{}
 
@@ -118,7 +140,7 @@ func TestDownCommandHandler_Handle_OrchestratorFails(t *testing.T) {
 
 func TestDownCommandHandler_Handle_MultipleCalls(t *testing.T) {
 	orchestrator := &mockDownOrchestrator{}
-	handler := NewDownCommandHandler(&mockDownServiceRepo{}, &mockDownRegistryRepo{}, orchestrator, &mockDownHookExecutor{})
+	handler := NewDownCommandHandler(&mockDownServiceRepo{}, &mockDownRegistryRepo{}, orchestrator, &mockDownHookExecutor{}, &mockDownTunnelManager{})
 
 	// Call Handle twice
 	_ = handler.Handle(context.Background(), DownCommand{})

--- a/internal/application/wiring/wiring.go
+++ b/internal/application/wiring/wiring.go
@@ -136,6 +136,7 @@ func NewContainerWithConfig(orchestrationRoot, servicesPath string, configResolv
 		registryRepo,
 		orchestrator,
 		hookExecutor,
+		tunnelManager,
 	)
 	restartHandler := commands.NewRestartCommandHandler(orchestrator)
 

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -113,6 +113,7 @@ type S3Config struct {
 type BucketConfig struct {
 	Name string `yaml:"name"`
 	Seed string `yaml:"seed,omitempty"`
+	CORS bool   `yaml:"cors,omitempty"`
 }
 
 type TunnelConfig struct {

--- a/internal/domain/infrastructure/infrastructure.go
+++ b/internal/domain/infrastructure/infrastructure.go
@@ -101,6 +101,7 @@ type S3Config struct {
 type BucketConfig struct {
 	Name string
 	Seed string
+	CORS bool
 }
 
 // TunnelRequirement represents tunnel infrastructure needs

--- a/internal/infrastructure/aws/provisioner.go
+++ b/internal/infrastructure/aws/provisioner.go
@@ -12,6 +12,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
@@ -226,6 +227,26 @@ func (p *LocalStackProvisioner) ProvisionLocalStack(ctx context.Context, req inf
 					return nil, fmt.Errorf("failed to create bucket %s: %w", bucket.Name, err)
 				}
 				ui.Successf("Created S3 bucket: %s", bucket.Name)
+			}
+
+			if bucket.CORS {
+				ui.SubStep("Configuring CORS for bucket: %s", bucket.Name)
+				_, err := s3Client.PutBucketCors(ctx, &s3.PutBucketCorsInput{
+					Bucket: aws.String(bucket.Name),
+					CORSConfiguration: &s3types.CORSConfiguration{
+						CORSRules: []s3types.CORSRule{
+							{
+								AllowedOrigins: []string{"*"},
+								AllowedMethods: []string{"GET", "PUT", "POST", "DELETE", "HEAD"},
+								AllowedHeaders: []string{"*"},
+							},
+						},
+					},
+				})
+				if err != nil {
+					return nil, fmt.Errorf("failed to configure CORS for bucket %s: %w", bucket.Name, err)
+				}
+				ui.Successf("Configured CORS for bucket: %s", bucket.Name)
 			}
 
 			// Store provisioned bucket details (use path-style URL for LocalStack)

--- a/internal/infrastructure/config/service_repository.go
+++ b/internal/infrastructure/config/service_repository.go
@@ -204,6 +204,7 @@ type S3ConfigDTO struct {
 type BucketConfigDTO struct {
 	Name string `yaml:"name"`
 	Seed string `yaml:"seed,omitempty"`
+	CORS bool   `yaml:"cors,omitempty"`
 }
 
 // HooksDTO is the DTO for hooks YAML serialization
@@ -368,6 +369,7 @@ func (r *ServiceRepositoryImpl) toInfrastructureRequirements(dto InfrastructureC
 			buckets = append(buckets, infrastructure.BucketConfig{
 				Name: b.Name,
 				Seed: b.Seed,
+				CORS: b.CORS,
 			})
 		}
 		req.S3 = &infrastructure.S3Config{Buckets: buckets}

--- a/internal/infrastructure/tunnel/cloudflared.go
+++ b/internal/infrastructure/tunnel/cloudflared.go
@@ -4,8 +4,10 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
+	"syscall"
 	"time"
 )
 
@@ -29,49 +31,85 @@ func (p *CloudflaredProvider) Name() string {
 
 // Start creates a tunnel using cloudflared
 func (p *CloudflaredProvider) Start(ctx context.Context, name string, localAddr string) (*Tunnel, error) {
-	// Check if cloudflared is installed
 	if _, err := exec.LookPath("cloudflared"); err != nil {
 		return nil, fmt.Errorf("cloudflared not found in PATH: install with 'brew install cloudflared': %w", err)
 	}
 
-	// Start cloudflared tunnel
-	cmd := exec.CommandContext(ctx, "cloudflared", "tunnel", "--url", fmt.Sprintf("http://%s", localAddr))
-
-	stderr, err := cmd.StderrPipe()
+	// Write stderr to a temp file instead of a pipe.
+	// Pipes cause SIGPIPE when the parent exits (read end closes),
+	// killing the detached child. A file has no such coupling.
+	logFile, err := os.CreateTemp("", "cloudflared-*.log")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get stderr pipe: %w", err)
+		return nil, fmt.Errorf("failed to create temp log file: %w", err)
 	}
+	logPath := logFile.Name()
+
+	cmd := exec.Command("cloudflared", "tunnel", "--url", fmt.Sprintf("http://%s", localAddr))
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stderr = logFile
+	cmd.Stdout = nil
+	cmd.Stdin = nil
 
 	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		os.Remove(logPath)
 		return nil, fmt.Errorf("failed to start cloudflared: %w", err)
 	}
 
-	// Wait for URL with timeout
+	// Close the write handle — the child has its own fd now.
+	// This fully severs the parent from the child's I/O.
+	logFile.Close()
+
+	// Poll the log file for the URL
 	urlChan := make(chan string, 1)
+	errChan := make(chan error, 1)
 	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if matches := cloudflaredURLPattern.FindStringSubmatch(line); len(matches) > 1 {
-				urlChan <- matches[1]
-				return
+		// Open our own read handle
+		f, err := os.Open(logPath)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to open log file for reading: %w", err)
+			return
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for {
+			if scanner.Scan() {
+				line := scanner.Text()
+				if matches := cloudflaredURLPattern.FindStringSubmatch(line); len(matches) > 1 {
+					urlChan <- matches[1]
+					return
+				}
+			} else {
+				// No more data yet — wait and retry (file is still being written)
+				time.Sleep(100 * time.Millisecond)
+				// Reset scanner to pick up new content
+				scanner = bufio.NewScanner(f)
 			}
 		}
 	}()
 
 	select {
 	case url := <-urlChan:
+		// Clean up the temp log file — child keeps running independently
+		os.Remove(logPath)
 		return &Tunnel{
 			Name:      name,
 			PublicURL: url,
 			LocalAddr: localAddr,
 			Process:   cmd.Process,
 		}, nil
+	case err := <-errChan:
+		_ = cmd.Process.Kill()
+		os.Remove(logPath)
+		return nil, err
 	case <-time.After(30 * time.Second):
 		_ = cmd.Process.Kill()
+		os.Remove(logPath)
 		return nil, fmt.Errorf("timeout waiting for cloudflared URL after 30 seconds")
 	case <-ctx.Done():
 		_ = cmd.Process.Kill()
+		os.Remove(logPath)
 		return nil, fmt.Errorf("context cancelled while waiting for cloudflared URL: %w", ctx.Err())
 	}
 }

--- a/internal/infrastructure/tunnel/manager.go
+++ b/internal/infrastructure/tunnel/manager.go
@@ -2,8 +2,12 @@ package tunnel
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
+	"syscall"
 
 	"github.com/Saturn-Fintech/grund/internal/application/ports"
 	"github.com/Saturn-Fintech/grund/internal/config"
@@ -66,7 +70,9 @@ func (m *Manager) ValidateConfig(cfg *config.TunnelConfig) error {
 	return nil
 }
 
-// StartAll starts tunnels for all targets in the config
+// StartAll starts tunnels for all targets in the config.
+// Before starting a new tunnel, it checks for an existing PID file.
+// If the process is still alive, it reuses the existing tunnel.
 func (m *Manager) StartAll(ctx context.Context, cfg *config.TunnelConfig, resolvedTargets []ports.ResolvedTunnelTarget) ([]ports.TunnelInfo, error) {
 	if cfg == nil || len(cfg.Targets) == 0 {
 		return nil, nil
@@ -84,14 +90,48 @@ func (m *Manager) StartAll(ctx context.Context, cfg *config.TunnelConfig, resolv
 	var startedTunnels []*Tunnel
 	for _, target := range resolvedTargets {
 		localAddr := fmt.Sprintf("%s:%s", target.Host, target.Port)
+
+		// Check for existing PID file — reuse if process is still alive
+		if state, err := readPIDFile(target.Name); err == nil && isProcessAlive(state.PID) {
+			m.tunnels[target.Name] = &Tunnel{
+				Name:      state.Name,
+				PublicURL: state.PublicURL,
+				LocalAddr: state.LocalAddr,
+				Process:   nil, // we don't own the process handle
+			}
+			tunnelInfos = append(tunnelInfos, ports.TunnelInfo{
+				Name:      state.Name,
+				PublicURL: state.PublicURL,
+				LocalAddr: state.LocalAddr,
+			})
+			continue
+		}
+
 		tunnel, err := provider.Start(ctx, target.Name, localAddr)
 		if err != nil {
 			// Cleanup any started tunnels
 			for _, t := range startedTunnels {
 				_ = provider.Stop(t)
+				_ = removePIDFile(t.Name)
 			}
 			return nil, fmt.Errorf("failed to start tunnel %s: %w", target.Name, err)
 		}
+
+		// Persist PID file so the tunnel can be tracked across CLI invocations
+		if tunnel.Process != nil {
+			state := TunnelState{
+				PID:       tunnel.Process.Pid,
+				Name:      tunnel.Name,
+				PublicURL: tunnel.PublicURL,
+				LocalAddr: tunnel.LocalAddr,
+				Provider:  cfg.Provider,
+			}
+			if writeErr := writePIDFile(tunnel.Name, state); writeErr != nil {
+				// Non-fatal: tunnel works, just can't be tracked later
+				fmt.Fprintf(os.Stderr, "warning: failed to write PID file for tunnel %s: %v\n", tunnel.Name, writeErr)
+			}
+		}
+
 		startedTunnels = append(startedTunnels, tunnel)
 		m.tunnels[target.Name] = tunnel
 		tunnelInfos = append(tunnelInfos, ports.TunnelInfo{
@@ -104,20 +144,53 @@ func (m *Manager) StartAll(ctx context.Context, cfg *config.TunnelConfig, resolv
 	return tunnelInfos, nil
 }
 
-// StopAll stops all running tunnels
+// StopAll stops all running tunnels by reading PID files from disk.
+// This works across CLI invocations — it does not require the same
+// Manager instance that started the tunnels.
 func (m *Manager) StopAll() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	var lastErr error
-	for name, tunnel := range m.tunnels {
-		if tunnel.Process != nil {
-			if err := tunnel.Process.Kill(); err != nil {
+
+	// Kill in-memory tunnels
+	for name, tun := range m.tunnels {
+		if tun.Process != nil {
+			if err := tun.Process.Kill(); err != nil {
 				lastErr = fmt.Errorf("failed to stop tunnel %s: %w", name, err)
 			}
 		}
+		_ = removePIDFile(name)
 		delete(m.tunnels, name)
 	}
+
+	// Also kill tunnels tracked only on disk (started by a previous CLI run)
+	dir, err := getTunnelsDir()
+	if err != nil {
+		return lastErr
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return lastErr
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		name := entry.Name()[:len(entry.Name())-len(".json")]
+		state, err := readPIDFile(name)
+		if err != nil {
+			_ = removePIDFile(name)
+			continue
+		}
+		if isProcessAlive(state.PID) {
+			if err := syscall.Kill(state.PID, syscall.SIGTERM); err != nil {
+				lastErr = fmt.Errorf("failed to stop tunnel %s (pid %d): %w", name, state.PID, err)
+			}
+		}
+		_ = removePIDFile(name)
+	}
+
 	return lastErr
 }
 
@@ -135,6 +208,72 @@ func (m *Manager) GetTunnels() map[string]ports.TunnelInfo {
 		}
 	}
 	return result
+}
+
+// getTunnelsDir returns the directory for tunnel PID files (~/.grund/tmp/tunnels)
+func getTunnelsDir() (string, error) {
+	grundHome, err := config.GetGrundHome()
+	if err != nil {
+		return "", fmt.Errorf("failed to get grund home: %w", err)
+	}
+	dir := filepath.Join(grundHome, "tmp", "tunnels")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("failed to create tunnels directory: %w", err)
+	}
+	return dir, nil
+}
+
+// writePIDFile persists tunnel state to a JSON file
+func writePIDFile(name string, state TunnelState) error {
+	dir, err := getTunnelsDir()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal tunnel state: %w", err)
+	}
+	path := filepath.Join(dir, name+".json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("failed to write PID file: %w", err)
+	}
+	return nil
+}
+
+// readPIDFile reads tunnel state from a JSON file
+func readPIDFile(name string) (*TunnelState, error) {
+	dir, err := getTunnelsDir()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, name+".json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read PID file: %w", err)
+	}
+	var state TunnelState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal tunnel state: %w", err)
+	}
+	return &state, nil
+}
+
+// removePIDFile deletes the PID file for a tunnel
+func removePIDFile(name string) error {
+	dir, err := getTunnelsDir()
+	if err != nil {
+		return err
+	}
+	return os.Remove(filepath.Join(dir, name+".json"))
+}
+
+// isProcessAlive checks if a process with the given PID is still running
+func isProcessAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	// Signal 0 checks if the process exists without sending a signal
+	return syscall.Kill(pid, 0) == nil
 }
 
 // Ensure Manager implements ports.TunnelManager

--- a/internal/infrastructure/tunnel/ngrok.go
+++ b/internal/infrastructure/tunnel/ngrok.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -31,57 +33,87 @@ func (p *NgrokProvider) Name() string {
 
 // Start creates a tunnel using ngrok
 func (p *NgrokProvider) Start(ctx context.Context, name string, localAddr string) (*Tunnel, error) {
-	// Check if ngrok is installed
 	if _, err := exec.LookPath("ngrok"); err != nil {
 		return nil, fmt.Errorf("ngrok not found in PATH: install from https://ngrok.com/download: %w", err)
 	}
 
-	// Extract port from localAddr
 	parts := strings.Split(localAddr, ":")
 	port := parts[len(parts)-1]
 
-	// Start ngrok with JSON logging
-	cmd := exec.CommandContext(ctx, "ngrok", "http", port, "--log", "stdout", "--log-format", "json")
-
-	stdout, err := cmd.StdoutPipe()
+	// Write stdout to a temp file instead of a pipe.
+	// Pipes cause SIGPIPE when the parent exits (read end closes),
+	// killing the detached child. A file has no such coupling.
+	logFile, err := os.CreateTemp("", "ngrok-*.log")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get stdout pipe: %w", err)
+		return nil, fmt.Errorf("failed to create temp log file: %w", err)
 	}
+	logPath := logFile.Name()
+
+	cmd := exec.Command("ngrok", "http", port, "--log", "stdout", "--log-format", "json")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Stdout = logFile
+	cmd.Stderr = nil
+	cmd.Stdin = nil
 
 	if err := cmd.Start(); err != nil {
+		logFile.Close()
+		os.Remove(logPath)
 		return nil, fmt.Errorf("failed to start ngrok: %w", err)
 	}
 
-	// Wait for URL with timeout
+	// Close the write handle — the child has its own fd now.
+	logFile.Close()
+
+	// Poll the log file for the URL
 	urlChan := make(chan string, 1)
+	errChan := make(chan error, 1)
 	go func() {
-		scanner := bufio.NewScanner(stdout)
-		for scanner.Scan() {
-			line := scanner.Text()
-			var entry ngrokLogEntry
-			if err := json.Unmarshal([]byte(line), &entry); err != nil {
-				continue
-			}
-			if entry.URL != "" && strings.HasPrefix(entry.URL, "https://") {
-				urlChan <- entry.URL
-				return
+		f, err := os.Open(logPath)
+		if err != nil {
+			errChan <- fmt.Errorf("failed to open log file for reading: %w", err)
+			return
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(f)
+		for {
+			if scanner.Scan() {
+				line := scanner.Text()
+				var entry ngrokLogEntry
+				if err := json.Unmarshal([]byte(line), &entry); err != nil {
+					continue
+				}
+				if entry.URL != "" && strings.HasPrefix(entry.URL, "https://") {
+					urlChan <- entry.URL
+					return
+				}
+			} else {
+				time.Sleep(100 * time.Millisecond)
+				scanner = bufio.NewScanner(f)
 			}
 		}
 	}()
 
 	select {
 	case url := <-urlChan:
+		os.Remove(logPath)
 		return &Tunnel{
 			Name:      name,
 			PublicURL: url,
 			LocalAddr: localAddr,
 			Process:   cmd.Process,
 		}, nil
+	case err := <-errChan:
+		_ = cmd.Process.Kill()
+		os.Remove(logPath)
+		return nil, err
 	case <-time.After(30 * time.Second):
 		_ = cmd.Process.Kill()
+		os.Remove(logPath)
 		return nil, fmt.Errorf("timeout waiting for ngrok URL after 30 seconds")
 	case <-ctx.Done():
 		_ = cmd.Process.Kill()
+		os.Remove(logPath)
 		return nil, fmt.Errorf("context cancelled while waiting for ngrok URL: %w", ctx.Err())
 	}
 }

--- a/internal/infrastructure/tunnel/provider.go
+++ b/internal/infrastructure/tunnel/provider.go
@@ -18,6 +18,15 @@ type Tunnel struct {
 	Process   *os.Process // the tunnel process
 }
 
+// TunnelState represents persisted tunnel state for PID file serialization
+type TunnelState struct {
+	PID       int    `json:"pid"`
+	Name      string `json:"name"`
+	PublicURL string `json:"public_url"`
+	LocalAddr string `json:"local_addr"`
+	Provider  string `json:"provider"`
+}
+
 // Provider defines the interface for tunnel providers
 type Provider interface {
 	// Start creates a tunnel to the given local address


### PR DESCRIPTION
## Summary
- **Tunnel persistence:** Detach tunnel child processes (cloudflared/ngrok) so they survive CLI exit. PID files under `~/.grund/tmp/tunnels/` allow `grund down` to kill tunnels from a previous `grund up`, and reuse still-alive tunnels instead of spawning duplicates.
- **S3 CORS:** Add `cors: true` bucket config option. When enabled, `PutBucketCors` is called after bucket creation with permissive rules (`*` origins, all methods/headers) so browser uploads through cloudflared tunnels aren't blocked by CORS.

## Test plan
- [x] `make build` compiles cleanly
- [x] `make test` — all existing tests pass (including race detection)
- [ ] Manual: add `cors: true` to a bucket in `grund.yaml`, run `grund up`, verify browser uploads work through tunnel
- [ ] Manual: run `grund up` with tunnels, kill CLI, run `grund down` — verify tunnels are stopped via PID files

🤖 Generated with [Claude Code](https://claude.com/claude-code)