### PR TITLE
chore: Bump version to 0.6.1

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -40,7 +40,7 @@ Configuration:
   grund config show           View configuration
 
 Documentation: https://github.com/Saturn-Fintech/grund`,
-	Version: "0.6.0",
+	Version: "0.6.1",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Set verbose mode on logger
 		ui.SetVerbose(verbose)


### PR DESCRIPTION
## Summary
- Bump version from 0.6.0 to 0.6.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)