### PR TITLE
feat: cross-platform distribution via GoReleaser (Homebrew, Scoop, deb/rpm)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: "~> 2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -168,6 +168,9 @@ docker-compose.override.yaml
 # Plan files
 docs/plans/
 
+# Claude Code planning artifacts
+docs/superpowers/
+
 # Local development data
 .localdev/
 .grund/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,82 @@
+version: 2
+
+project_name: grund
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      - "386"
+    ignore:
+      - goos: darwin
+        goarch: "386"
+      - goos: windows
+        goarch: "386"
+    ldflags:
+      - -s -w -X github.com/GrundIO/grund/internal/cli.Version={{.Version}}
+    main: .
+
+archives:
+  - id: default
+    formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - README.md
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^chore:"
+      - "^docs:"
+      - "^test:"
+
+nfpms:
+  - id: packages
+    package_name: grund
+    homepage: https://github.com/GrundIO/grund
+    description: Local development orchestration tool for microservices
+    maintainer: Vivek Kundariya <vivekkundariya.temp@gmail.com>
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+
+homebrew_casks:
+  - name: grund
+    binaries:
+      - grund
+    repository:
+      owner: GrundIO
+      name: homebrew-grund
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/GrundIO/grund
+    description: Local development orchestration tool for microservices
+
+scoops:
+  - name: grund
+    repository:
+      owner: GrundIO
+      name: scoop-grund
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
+    homepage: https://github.com/GrundIO/grund
+    description: Local development orchestration tool for microservices
+    license: MIT

--- a/README.md
+++ b/README.md
@@ -47,7 +47,35 @@ Grund automatically:
 
 ## Installation
 
-### Using Go Install
+### macOS (Homebrew)
+
+```bash
+brew tap GrundIO/grund
+brew install --cask grund
+```
+
+### Windows (Scoop)
+
+```bash
+scoop bucket add grundio https://github.com/GrundIO/scoop-grund
+scoop install grund
+```
+
+### Linux
+
+Download the latest `.deb` or `.rpm` from the [GitHub Releases page](https://github.com/GrundIO/grund/releases):
+
+```bash
+# Debian / Ubuntu
+dpkg -i grund_<version>_linux_amd64.deb
+
+# Fedora / RHEL
+rpm -i grund_<version>_linux_amd64.rpm
+```
+
+Or download the raw binary for your architecture directly from [GitHub Releases](https://github.com/GrundIO/grund/releases).
+
+### Using Go Install (for developers)
 
 ```bash
 go install github.com/GrundIO/grund@latest

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -16,6 +16,8 @@ var (
 	// CLI flags
 	configFile string
 	verbose    bool
+
+	Version = "dev"
 )
 
 var rootCmd = &cobra.Command{
@@ -40,7 +42,7 @@ Configuration:
   grund config show           View configuration
 
 Documentation: https://github.com/GrundIO/grund`,
-	Version: "0.6.1",
+	Version: Version,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Set verbose mode on logger
 		ui.SetVerbose(verbose)


### PR DESCRIPTION
## Summary

Merges the cross-platform distribution feature from `develop` into `main`.

- Automated releases triggered by `git tag v*.*.*`
- Builds binaries for macOS (arm64/amd64), Linux (arm64/amd64/386), Windows (amd64/arm64)
- Publishes Homebrew cask to `GrundIO/homebrew-grund`, Scoop manifest to `GrundIO/scoop-grund`, `.deb`/`.rpm` to GitHub Releases
- Version now injected via ldflags at build time (`dev` locally, real version in releases)

## Install commands after first release

```bash
# macOS
brew tap GrundIO/grund && brew install --cask grund

# Windows
scoop bucket add grundio https://github.com/GrundIO/scoop-grund && scoop install grund

# Linux (Debian/Ubuntu)
dpkg -i grund_<version>_linux_amd64.deb

# Linux (Fedora/RHEL)
rpm -i grund_<version>_linux_amd64.rpm
```

## To trigger first release after merge

```bash
git checkout main && git pull
git tag v0.7.0
git push origin v0.7.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)